### PR TITLE
Only software interrupt bits are writable into the Cause register

### DIFF
--- a/vr4300/cp0.c
+++ b/vr4300/cp0.c
@@ -85,8 +85,16 @@ int VR4300_DMTC0(struct vr4300 *vr4300,
   uint32_t iw, uint64_t rs, uint64_t rt) {
   unsigned dest = GET_RD(iw);
 
-  if ((dest + VR4300_REGISTER_CP0_0) == VR4300_CP0_REGISTER_COMPARE)
-    vr4300->regs[VR4300_CP0_REGISTER_CAUSE] &= ~0x8000;
+  switch (dest + VR4300_REGISTER_CP0_0)
+  {
+    case VR4300_CP0_REGISTER_CAUSE:
+      vr4300->regs[VR4300_CP0_REGISTER_CAUSE] &= ~0x0300;
+      vr4300->regs[VR4300_CP0_REGISTER_CAUSE] |= rt & 0x0300;
+      return 0;
+    case VR4300_CP0_REGISTER_COMPARE:
+      vr4300->regs[VR4300_CP0_REGISTER_CAUSE] &= ~0x8000;
+      break;
+  }
 
   if (vr4300_cp0_reg_masks[dest] == 0x0000000000000BADULL)
     vr4300->regs[VR4300_REGISTER_CP0_0 + 7] = rt;
@@ -171,12 +179,19 @@ int VR4300_MTC0(struct vr4300 *vr4300,
   struct vr4300_exdc_latch *exdc_latch = &vr4300->pipeline.exdc_latch;
   unsigned dest = GET_RD(iw);
 
-  if ((dest + VR4300_REGISTER_CP0_0) == VR4300_CP0_REGISTER_COMPARE)
-    vr4300->regs[VR4300_CP0_REGISTER_CAUSE] &= ~0x8000;
-
-  else if ((dest + VR4300_REGISTER_CP0_0) == VR4300_CP0_REGISTER_STATUS) {
-    icrf_latch->segment = get_segment(icrf_latch->common.pc, rt);
-    exdc_latch->segment = get_default_segment();
+  switch (dest + VR4300_REGISTER_CP0_0)
+  {
+    case VR4300_CP0_REGISTER_CAUSE:
+      vr4300->regs[VR4300_CP0_REGISTER_CAUSE] &= ~0x0300;
+      vr4300->regs[VR4300_CP0_REGISTER_CAUSE] |= (int32_t)rt & 0x0300;
+      return 0;
+    case VR4300_CP0_REGISTER_COMPARE:
+      vr4300->regs[VR4300_CP0_REGISTER_CAUSE] &= ~0x8000;
+      break;
+    case VR4300_CP0_REGISTER_STATUS:
+      icrf_latch->segment = get_segment(icrf_latch->common.pc, rt);
+      exdc_latch->segment = get_default_segment();
+      break;
   }
 
   if (vr4300_cp0_reg_masks[dest] == 0x0000000000000BADULL)


### PR DESCRIPTION
See: VR4300 user manual, chapter 6.3.6.

![image](https://user-images.githubusercontent.com/15223353/50407428-2d3f5880-07d7-11e9-98f8-9b918e17e3fb.png)

>All the bits, except IP1 and IP0, are read-only.  The IP1 and IP0 bits are used to generate the software interrupt.

There's possibly a risk of software overriding the timer interrupt and external normal interrupts (the 5 interrupt pins on the CPU, of which the RCP, expansion device and Pre-NMI signals are wired) with their own values (they could either be outdated, or just plain wrong).