### PR TITLE
Extract all VR4300 interfaces to interface.h

### DIFF
--- a/bus/controller.c
+++ b/bus/controller.c
@@ -22,7 +22,6 @@
 #include "rsp/cpu.h"
 #include "rsp/interface.h"
 #include "vi/controller.h"
-#include "vr4300/cpu.h"
 #include "vr4300/interface.h"
 
 #define NUM_MAPPINGS 17

--- a/device/device.h
+++ b/device/device.h
@@ -25,14 +25,14 @@
 #include "rsp/cpu.h"
 #include "thread.h"
 #include "vi/controller.h"
-#include "vr4300/cpu.h"
+#include "vr4300/interface.h"
 
 // Only used when passed -nointerface.
 extern bool device_exit_requested;
 
 struct cen64_device {
   struct bus_controller bus;
-  struct vr4300 vr4300;
+  struct vr4300* vr4300;
 
   struct ai_controller ai;
   struct dd_controller dd;

--- a/device/netapi.c
+++ b/device/netapi.c
@@ -23,8 +23,7 @@
 
 #include "device/device.h"
 #include "device/netapi.h"
-#include "vr4300/cpu.h"
-#include "vr4300/pipeline.h"
+#include "vr4300/interface.h"
 
 // TODO: Really sloppy.
 #ifdef __WIN32__
@@ -178,11 +177,11 @@ int netapi_debug_handle_request(int sfd, struct cen64_device *device,
       length = sizeof(uint64_t) * 33;
 
       for (i = 0; i < 32; i++) {
-        u64 = htonll(device->vr4300.regs[i]);
+        u64 = htonll(vr4300_get_register(device->vr4300, i));
         memcpy(data + i * sizeof(u64), &u64, sizeof(u64));
       }
 
-      u64 = htonll(device->vr4300.pipeline.dcwb_latch.common.pc);
+      u64 = htonll(vr4300_get_pc(device->vr4300));
       memcpy(data + 32 * sizeof(u64), &u64, sizeof(u64));
       break;
 

--- a/vr4300/cp1.h
+++ b/vr4300/cp1.h
@@ -56,7 +56,5 @@ int VR4300_CP1_SUB(struct vr4300 *vr4300, uint32_t iw, uint64_t fs, uint64_t ft)
 int VR4300_CP1_TRUNC_L(struct vr4300 *vr4300, uint32_t iw, uint64_t fs, uint64_t ft);
 int VR4300_CP1_TRUNC_W(struct vr4300 *vr4300, uint32_t iw, uint64_t fs, uint64_t ft);
 
-cen64_cold void vr4300_cp1_init(struct vr4300 *vr4300);
-
 #endif
 

--- a/vr4300/cpu.h
+++ b/vr4300/cpu.h
@@ -117,26 +117,5 @@ cen64_cold void vr4300_print_summary(struct vr4300_stats *stats);
 
 cen64_flatten cen64_hot void vr4300_cycle_(struct vr4300 *vr4300);
 
-cen64_flatten cen64_hot static inline void vr4300_cycle(struct vr4300 *vr4300) {
-  struct vr4300_pipeline *pipeline = &vr4300->pipeline;
-
-  // Increment counters.
-  vr4300->regs[VR4300_CP0_REGISTER_COUNT]++;
-
-  if ((uint32_t) (vr4300->regs[VR4300_CP0_REGISTER_COUNT] >> 1) ==
-    (uint32_t) vr4300->regs[VR4300_CP0_REGISTER_COMPARE])
-    vr4300->regs[VR4300_CP0_REGISTER_CAUSE] |= 0x8000;
-
-  // We're stalling for something...
-  if (pipeline->cycles_to_stall > 0)
-    pipeline->cycles_to_stall--;
-
-  else
-    vr4300_cycle_(vr4300);
-}
-
-
-cen64_cold void vr4300_cycle_extra(struct vr4300 *vr4300, struct vr4300_stats *stats);
-
 #endif
 

--- a/vr4300/interface.c
+++ b/vr4300/interface.c
@@ -182,3 +182,13 @@ int write_mi_regs(void *opaque, uint32_t address, uint32_t word, uint32_t dqm) {
   return 0;
 }
 
+int has_profile_samples(struct vr4300 const *vr4300)
+{
+    return vr4300->profile_samples != NULL;
+}
+
+uint64_t get_profile_sample(struct vr4300 const *vr4300, size_t i)
+{
+    return vr4300->profile_samples[i];
+}
+

--- a/vr4300/interface.h
+++ b/vr4300/interface.h
@@ -11,7 +11,6 @@
 #ifndef __vr4300_interface_h__
 #define __vr4300_interface_h__
 #include "common.h"
-#include "vr4300/cpu.h"
 
 enum rcp_interrupt_mask {
   MI_INTR_SP = 0x01,
@@ -22,6 +21,24 @@ enum rcp_interrupt_mask {
   MI_INTR_DP = 0x20
 };
 
+struct vr4300;
+struct vr4300_stats;
+
+cen64_cold struct vr4300* vr4300_alloc();
+cen64_cold void vr4300_free(struct vr4300*);
+
+cen64_cold struct vr4300_stats* vr4300_stats_alloc();
+cen64_cold void vr4300_stats_free(struct vr4300_stats*);
+    
+cen64_cold int vr4300_init(struct vr4300 *vr4300, struct bus_controller *bus, bool profiling);
+cen64_cold void vr4300_cp1_init(struct vr4300 *vr4300);
+
+cen64_flatten cen64_hot void vr4300_cycle(struct vr4300 *vr4300);
+cen64_cold void vr4300_cycle_extra(struct vr4300 *vr4300, struct vr4300_stats *stats);
+
+uint64_t vr4300_get_register(struct vr4300 *vr4300, size_t i);
+uint64_t vr4300_get_pc(struct vr4300 *vr4300);
+
 int read_mi_regs(void *opaque, uint32_t address, uint32_t *word);
 int write_mi_regs(void *opaque, uint32_t address, uint32_t word, uint32_t dqm);
 
@@ -30,6 +47,9 @@ void signal_rcp_interrupt(struct vr4300 *vr4300, enum rcp_interrupt_mask mask);
 
 void clear_dd_interrupt(struct vr4300 *vr4300);
 void signal_dd_interrupt(struct vr4300 *vr4300);
+
+uint64_t get_profile_sample(struct vr4300 const *vr4300, size_t i);
+int has_profile_samples(struct vr4300 const *vr4300);
 
 #endif
 


### PR DESCRIPTION
In this patch we encapsulate VR4300 internals from other devices, and now they have to include only `vr4300/interface.h` header. It makes possible to use alternative models of VR4300 if they implement the same interfaces. But there is a drawback: we allocate `vr4300` structure on heap now.