### PR TITLE
device/sha1.c: Remove sys/cdefs.h include

### DIFF
--- a/device/sha1.c
+++ b/device/sha1.c
@@ -40,7 +40,6 @@
 #else
 #include <string.h>
 #include <sys/types.h>
-#include <sys/cdefs.h>
 #include <sys/time.h>
 #endif
 


### PR DESCRIPTION
sys/cdefs.h is an internal glibc header. It's not supposed to be used by programs. Cen64 builds fine without it.