### PR TITLE
Clear the frame buffer to avoid garbage

### DIFF
--- a/vi/render.c
+++ b/vi/render.c
@@ -51,6 +51,8 @@ void gl_window_render_frame(struct vi_controller *vi, const uint8_t *buffer,
   unsigned hres, unsigned vres, unsigned hskip, unsigned type) {
   float aspect;
 
+  glClear(GL_COLOR_BUFFER_BIT);
+
   switch(type) {
     case 0:
       return;


### PR DESCRIPTION
Some graphics stacks just suck (like AMD + Mesa), so we have to clear the frame buffer on each frame, otherwise garbage and/or flickering appears on undrawn areas.

Fixes #53.