### PR TITLE
PI: name constants and fixed DMA/reset controller behaviour

### DIFF
--- a/pi/controller.c
+++ b/pi/controller.c
@@ -227,6 +227,11 @@ int write_pi_regs(void *opaque, uint32_t address, uint32_t word, uint32_t dqm) {
   }
 
   else {
+    if (pi->regs[PI_STATUS_REG] & PI_STATUS_IS_BUSY) {
+      pi->regs[PI_STATUS_REG] |= PI_STATUS_ERROR;
+      return 0;
+    }
+
     pi->regs[reg] &= ~dqm;
     pi->regs[reg] |= word;
 

--- a/pi/controller.h
+++ b/pi/controller.h
@@ -26,6 +26,19 @@ enum pi_register {
 extern const char *pi_register_mnemonics[NUM_PI_REGISTERS];
 #endif
 
+enum pi_status {
+  PI_STATUS_DMA_BUSY = 1 << 0,
+  PI_STATUS_IO_BUSY = 1 << 1,
+  PI_STATUS_ERROR = 1 << 2,
+  PI_STATUS_INTERRUPT = 1 << 3,
+  PI_STATUS_IS_BUSY = PI_STATUS_DMA_BUSY | PI_STATUS_IO_BUSY
+};
+
+enum pi_status_write {
+  PI_STATUS_RESET_CONTROLLER = 1 << 0,
+  PI_STATUS_CLEAR_INTERRUPT = 1 << 1
+};
+
 #define FLASHRAM_SIZE 0x20000
 
 enum flashram_mode {


### PR DESCRIPTION
When a reset controller request is performed, only busy and error bits are cleared.

When DMAs begin, the DMA busy bit is set, but the interrupt bit shouldn't be touched yet.

@tj90241 That lifelong mystery has finally been put to sleep, but oh man if the answer wasn't staring right at us !

Though on a serious note, I'd like feedback on `enum pi_status_write` and its members' names for consistency's sake: should I leave it like this or rename the members to `PI_STATUS_WRITE_*` ?