### PR TITLE
Prevent CEN64 from closing if -novideo is given

### DIFF
--- a/cen64.c
+++ b/cen64.c
@@ -431,7 +431,9 @@ int run_device(struct cen64_device *device, bool no_video) {
 
   cen64_thread_setname(thread, "device");
 
-  if (!no_video)
+  if (no_video)
+    pause();
+  else
     cen64_gl_window_thread(device);
 
   device->running = false;


### PR DESCRIPTION
Not sure if it is the best workaround, but works for me.