### PR TITLE
Preserve SP PC when clearing halt, don't re-init pipeline if not halted

### DIFF
--- a/rsp/cp0.c
+++ b/rsp/cp0.c
@@ -101,8 +101,12 @@ void rsp_status_write(struct rsp *rsp, uint32_t rt) {
     prev_status = rsp->regs[RSP_CP0_REGISTER_SP_STATUS];
     status = prev_status;
 
-    if (rt & SP_CLR_HALT) {
+    if ((rt & SP_CLR_HALT) && (status & SP_STATUS_HALT)) {
+      // Save PC around pipeline init
+      uint32_t pc = rsp->pipeline.ifrd_latch.pc;
       rsp_pipeline_init(&rsp->pipeline);
+      rsp->pipeline.ifrd_latch.pc = pc;
+
       status &= ~SP_STATUS_HALT;
     }
 


### PR DESCRIPTION
Fixes #151. I'm not sure how you usually deal with test cases, I attached one to the issue.