### PR TITLE
docs: fix simple typo, accesssor -> accessor

### DIFF
--- a/bus/controller.h
+++ b/bus/controller.h
@@ -48,7 +48,7 @@ struct bus_controller {
 
 cen64_cold int bus_init(struct bus_controller *bus, int dd_present);
 
-// General-purpose accesssor functions.
+// General-purpose accessor functions.
 cen64_flatten cen64_hot int bus_read_word(const struct bus_controller *bus,
   uint32_t address, uint32_t *word);
 


### PR DESCRIPTION
There is a small typo in bus/controller.h.

Should read `accessor` rather than `accesssor`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md