### PR TITLE
Implement gdb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,7 @@ set(VR4300_SOURCES
   ${PROJECT_SOURCE_DIR}/vr4300/cpu.c
   ${PROJECT_SOURCE_DIR}/vr4300/dcache.c
   ${PROJECT_SOURCE_DIR}/vr4300/decoder.c
+  ${PROJECT_SOURCE_DIR}/vr4300/debug.c
   ${PROJECT_SOURCE_DIR}/vr4300/fault.c
   ${PROJECT_SOURCE_DIR}/vr4300/functions.c
   ${PROJECT_SOURCE_DIR}/vr4300/icache.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,7 @@ set(BUS_SOURCES
 
 set(COMMON_SOURCES
   ${PROJECT_SOURCE_DIR}/common/debug.c
+  ${PROJECT_SOURCE_DIR}/common/hash_table.c
   ${PROJECT_SOURCE_DIR}/common/one_hot.c
   ${PROJECT_SOURCE_DIR}/common/reciprocal.c
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,11 @@ set(DEVICE_SOURCES
   ${PROJECT_SOURCE_DIR}/device/sha1.c
 )
 
+set(GDB_SOURCES
+  ${PROJECT_SOURCE_DIR}/gdb/gdb.c
+  ${PROJECT_SOURCE_DIR}/gdb/protocol.c
+)
+
 set(OS_SOURCES
   ${PROJECT_SOURCE_DIR}/os/common/gl_hints.c
   ${PROJECT_SOURCE_DIR}/os/common/input.c
@@ -438,6 +443,7 @@ add_executable(cen64
   ${COMMON_SOURCES}
   ${DD_SOURCES}
   ${DEVICE_SOURCES}
+  ${GDB_SOURCES}
   ${OS_SOURCES}
   ${PI_SOURCES}
   ${RDP_SOURCES}

--- a/bus/controller.h
+++ b/bus/controller.h
@@ -55,11 +55,5 @@ cen64_flatten cen64_hot int bus_read_word(const struct bus_controller *bus,
 cen64_flatten cen64_hot int bus_write_word(struct bus_controller *bus,
   uint32_t address, uint32_t word, uint32_t dqm);
 
-// For asserting and deasserting RCP interrupts.
-enum rcp_interrupt_mask;
-
-int raise_rcp_interrupt(struct bus_controller *bus,
-  enum rcp_interrupt_mask mask);
-
 #endif
 

--- a/cen64.c
+++ b/cen64.c
@@ -16,6 +16,7 @@
 #include "device/options.h"
 #include "device/sha1.h"
 #include "device/sha1_sums.h"
+#include "gdb/gdb.h"
 #include "os/common/alloc.h"
 #include "os/common/rom_file.h"
 #include "os/common/save_file.h"
@@ -179,6 +180,8 @@ int cen64_main(int argc, const char **argv) {
     }
   }
 
+
+
   // Allocate memory for and create the device.
   if (cen64_alloc(&cen64_device_mem, sizeof(*device), false) == NULL) {
     printf("Failed to allocate enough memory for a device.\n");
@@ -197,9 +200,20 @@ int cen64_main(int argc, const char **argv) {
     }
 
     else {
+      struct gdb* debugger = NULL;
+
+      if (options.debugger_addr) {
+        debugger = gdb_alloc();
+        gdb_init(debugger, device, options.debugger_addr);
+      }
+
       device->multithread = options.multithread;
       status = run_device(device, options.no_video);
       device_destroy(device, options.cart_path);
+
+      if (debugger) {
+        gdb_destroy(debugger);
+      }
     }
 
     cen64_free(&cen64_device_mem);

--- a/common/hash_table.c
+++ b/common/hash_table.c
@@ -1,0 +1,180 @@
+//
+// common/hash_table.c
+//
+// Simple hash table implementation
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+
+#include "hash_table.h"
+
+#define LARGE_PRIME 1048583
+// must be a power of 2
+#define MIN_TABLE_SIZE  16
+
+#define WRAP_INDEX(table, index) ((index) & ((table)->capacity - 1))
+
+struct hash_table_entry* hash_table_find_entry(struct hash_table* table, unsigned long key) {
+    if (table->capacity == 0) {
+        return NULL;
+    }
+
+    int startIndex = WRAP_INDEX(table, key * LARGE_PRIME);
+    int currentIndex = startIndex;
+
+    while (table->entries[currentIndex].used) {
+        if (table->entries[currentIndex].key == key) {
+            return table->entries + currentIndex;
+        }
+
+        currentIndex = WRAP_INDEX(table, currentIndex + 1);
+
+        // prevent an infinite loop
+        if (currentIndex == startIndex) {
+            return NULL;
+        }
+    }
+
+    return table->entries + currentIndex;
+}
+
+
+void hash_table_alloc(struct hash_table* table, int capacity) {
+    if (capacity) {
+        table->entries = malloc(sizeof(struct hash_table_entry) * capacity);
+    } else {
+        table->entries = NULL;
+    }
+
+    for (int i = 0; i < capacity; i++) {
+        table->entries[i].used = false;
+    }
+
+    table->capacity = capacity;
+    table->size = 0;
+}
+
+void hash_table_resize(struct hash_table* table, int capacity) {
+    struct hash_table newTable;
+    hash_table_alloc(&newTable, capacity);
+
+    for (int i = 0; i < table->capacity; i++) {
+        if (table->entries[i].used) {
+            struct hash_table_entry* newEntry = hash_table_find_entry(&newTable, table->entries[i].key);
+
+            newEntry->used = true;
+            newEntry->key = table->entries[i].key;
+            newEntry->value = table->entries[i].value;
+        }
+    }
+
+    hash_table_free(table);
+    *table = newTable;
+}
+
+void hash_table_init(struct hash_table* table, int capacity) {
+    int actualCapacity = MIN_TABLE_SIZE;
+
+    // capacity must be a power of 2
+    while (actualCapacity < capacity) {
+        actualCapacity <<= 1;
+    }
+
+    hash_table_alloc(table, actualCapacity);
+}
+
+void hash_table_free(struct hash_table* table) {
+    free(table->entries);
+    table->entries = NULL;
+    table->capacity = 0;
+    table->size = 0;
+}
+
+int hash_table_size(struct hash_table* table) {
+    return table->size;
+}
+
+int hash_table_capacity(struct hash_table* table) {
+    return table->capacity;
+}
+
+bool hash_table_get(struct hash_table* table, unsigned long key, unsigned long *value) {
+    if (table->capacity == 0) {
+        return false;
+    }
+
+    struct hash_table_entry* entry = hash_table_find_entry(table, key);
+    assert(entry);
+
+    if (entry->used) {
+        if (value) {
+            *value = entry->value;
+        }
+
+        return true;
+    } else {
+        return false;
+    }
+}
+
+void hash_table_set(struct hash_table* table, unsigned long key, unsigned long value) {
+    if (table->capacity == 0) {
+        hash_table_resize(table, MIN_TABLE_SIZE);
+    } else if (table->capacity / 2 < table->size) {
+        hash_table_resize(table, table->capacity * 2);
+    }
+
+    struct hash_table_entry* entry = hash_table_find_entry(table, key);
+    assert(entry);
+
+    if (!entry->used) {
+        table->size++;
+    }
+
+    entry->key = key;
+    entry->used = true;
+    entry->value = value;
+}
+
+
+void hash_table_check_holes(struct hash_table* table, int startIndex) {
+    int index = WRAP_INDEX(table, startIndex + 1);
+
+    while (startIndex != index && table->entries[index].used) {
+        struct hash_table_entry* prevEntry = &table->entries[index];
+        struct hash_table_entry* newEntry = hash_table_find_entry(table, prevEntry->key);
+        assert(newEntry);
+
+        if (newEntry != prevEntry) {
+            assert(!newEntry->used);
+    
+            newEntry->key = prevEntry->key;
+            newEntry->value = prevEntry->value;
+            newEntry->used = true;
+
+            prevEntry->used = false;
+        }
+
+        index = WRAP_INDEX(table, index + 1);
+    }
+}
+
+void hash_table_delete(struct hash_table* table, unsigned long key) {
+    if (table->capacity == 0) {
+        return;
+    } else if (table->capacity / 4 > table->size && table->capacity > MIN_TABLE_SIZE) {
+        hash_table_resize(table, table->capacity / 2);
+    }
+
+    struct hash_table_entry* entry = hash_table_find_entry(table, key);
+    assert(entry);
+
+    if (entry->used) {
+        entry->used = false;
+        table->size--;
+
+        // fill in the hole created by deleting this entry
+        hash_table_check_holes(table, entry - table->entries);
+    }
+}

--- a/common/hash_table.h
+++ b/common/hash_table.h
@@ -1,0 +1,37 @@
+//
+// common/hash_table.h
+//
+// Simple hash table implementation
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+
+#ifndef __common_hastable_h__
+#define __common_hastable_h__
+#include "common.h"
+
+struct hash_table_entry {
+    bool used;
+    unsigned long key;
+    unsigned long value;
+};
+
+struct hash_table {
+    struct hash_table_entry* entries;
+    int capacity;
+    int size;
+};
+
+
+void hash_table_init(struct hash_table* table, int capacity);
+void hash_table_free(struct hash_table* table);
+int hash_table_size(struct hash_table* table);
+int hash_table_capacity(struct hash_table* table);
+
+bool hash_table_get(struct hash_table* table, unsigned long key, unsigned long *value);
+void hash_table_set(struct hash_table* table, unsigned long key, unsigned long value);
+void hash_table_delete(struct hash_table* table, unsigned long key);
+
+#endif
+

--- a/device/device.c
+++ b/device/device.c
@@ -349,3 +349,6 @@ int device_debug_spin(struct cen64_device *device) {
   return 0;
 }
 
+cen64_cold void device_connect_debugger(struct cen64_device *device, void* break_handler_data, vr4300_debug_break_handler break_handler) {
+  vr4300_connect_debugger(device->vr4300, break_handler_data, break_handler);
+}

--- a/device/device.h
+++ b/device/device.h
@@ -67,5 +67,7 @@ cen64_cold struct cen64_device *device_create(struct cen64_device *device,
 cen64_cold void device_exit(struct bus_controller *bus);
 cen64_cold void device_run(struct cen64_device *device);
 
+cen64_cold void device_connect_debugger(struct cen64_device *device, void* break_handler_data, vr4300_debug_break_handler break_handler);
+
 #endif
 

--- a/gdb/gdb.c
+++ b/gdb/gdb.c
@@ -1,0 +1,260 @@
+//
+// gdb.c: gdb remote debugger implementation
+//
+// CEN64: Cycle-Accurate Nintendo 64 Emulator.
+// Copyright (C) 2015, Tyler J. Stachecki.
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+
+#include "gdb/gdb.h"
+#include "gdb/protocol.h"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <windows.h>
+#include <ws2tcpip.h>
+#else
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+cen64_cold void gdb_handle_breakpoint(void* data, enum vr4300_debug_break_reason reason);
+
+int gdb_read(struct gdb* gdb) {
+  if (gdb->pending_data >= MAX_GDB_PACKET_SIZE) {
+    // if the gdb client is well behaved this should never happen
+    gdb->pending_data = 0;
+  }
+
+  int bytes_read = recv(gdb->client, gdb->packet_buffer + gdb->pending_data, MAX_GDB_PACKET_SIZE, 0);
+
+  if (bytes_read > 0) {
+    gdb->pending_data += bytes_read;
+  }
+  
+
+  return bytes_read;
+}
+
+void gdb_mark_read(struct gdb* gdb, int handled_bytes) {
+  if (handled_bytes <= gdb->pending_data) {
+    gdb->pending_data -= handled_bytes;
+  } else {
+    gdb->pending_data = 0;
+  }
+
+  if (gdb->pending_data) {
+    for (int i = 0; i < gdb->pending_data; i++) {
+      gdb->packet_buffer[i] = gdb->packet_buffer[i + handled_bytes];
+    }
+  }
+}
+
+bool gdb_parse_packet(const char* input, int len, const char** command_start, const char** command_end) {
+    const char* string_end = input + len;
+
+    while (input < string_end) {
+        if (*input == '$') {
+            input++;
+            *command_start = input;
+            break;
+        }
+        input++;
+    }
+
+    while (input < string_end) {
+        if (*input == '#') {
+            *command_end = input;
+            return true;
+        } else {
+            input++;
+        }
+    }
+
+    return false;
+}
+
+CEN64_THREAD_RETURN_TYPE gdb_thread(void *opaque) {
+  cen64_thread_setname(NULL, "gdb");
+  struct gdb *gdb = (struct gdb *) opaque;
+
+  cen64_mutex_lock(&gdb->client_mutex);
+
+  // wait until first breakpoint is hit before entering loop
+  if (gdb->flags & GDB_FLAGS_INITIAL) {
+    cen64_cv_wait(&gdb->client_semaphore, &gdb->client_mutex);
+  } else {
+    cen64_mutex_lock(&gdb->client_mutex);
+  }
+
+  while (gdb->flags & GDB_FLAGS_CONNECTED) {
+    int bytes_read = gdb_read(gdb);
+
+    debug("rec: %.*s\n", bytes_read, gdb->packet_buffer + gdb->pending_data - bytes_read);
+
+    if (bytes_read <= 0) {
+      gdb->flags &= ~GDB_FLAGS_CONNECTED;
+      printf("Debug socket closed\n");
+      break;
+    }
+
+    const char* command_start;
+    const char* command_end;
+
+    bool did_handle = false;
+
+    do {
+      int handled_bytes = 0;
+
+      int search_end = gdb->pending_data;
+
+      if (gdb_parse_packet(gdb->packet_buffer, gdb->pending_data, &command_start, &command_end)) {
+        send(gdb->client, "+", strlen("+"), 0);
+        gdb_handle_packet(gdb, command_start, command_end);
+        
+        // +3, 1 byte for the '#' and 2 additional bytes for the checksum
+        handled_bytes = (command_end - gdb->packet_buffer) + 3;
+        search_end = command_start - gdb->packet_buffer;
+      }
+
+      int at;
+
+      for (at = 0; at < search_end && gdb->packet_buffer[at] != '$'; at++) {
+        if (gdb->packet_buffer[at] == 0x03) {
+          vr4300_signal_break(gdb->device->vr4300);
+        }
+      }
+
+      if (at > handled_bytes) {
+        handled_bytes = at;
+      }
+
+      bytes_read -= handled_bytes;
+      gdb_mark_read(gdb, handled_bytes);
+    } while (did_handle);
+
+  }
+
+  return CEN64_THREAD_RETURN_VAL;
+}
+
+cen64_cold void gdb_handle_breakpoint(void* data, enum vr4300_debug_break_reason reason) {
+  struct gdb* gdb = (struct gdb*)data;
+
+  debug("Stopping at 0x%08x\n", (uint32_t)vr4300_get_pc(gdb->device->vr4300));
+
+  if (!(gdb->flags & GDB_FLAGS_CONNECTED)) {
+    return;
+  } else if (gdb->flags & GDB_FLAGS_INITIAL) {
+    gdb->flags &= ~GDB_FLAGS_INITIAL;
+    vr4300_remove_breakpoint(gdb->device->vr4300, 0xFFFFFFFF80000000ULL);
+    cen64_cv_signal(&gdb->client_semaphore);
+  } else {
+    gdb_send_stop_reply(gdb, reason == VR4300_DEBUG_BREAK_REASON_BREAKPOINT);
+  }
+
+  cen64_mutex_lock(&gdb->client_mutex);
+  gdb->flags |= GDB_FLAGS_PAUSED;
+  cen64_cv_wait(&gdb->client_semaphore, &gdb->client_mutex);
+  gdb->flags &= ~GDB_FLAGS_PAUSED;
+
+  if (!(gdb->flags & GDB_FLAGS_CONNECTED)) {
+    vr4300_connect_debugger(gdb->device->vr4300, NULL, NULL);
+  }
+}
+
+cen64_cold struct gdb* gdb_alloc() {
+    struct gdb* result = malloc(sizeof(struct gdb));
+    memset(result, 0, sizeof(struct gdb));
+    return result;
+}
+
+cen64_cold bool gdb_init(struct gdb* gdb, struct cen64_device* device, const char* host) {
+  int port;
+  if (sscanf(host, "localhost:%d", &port) != 1) {
+    printf("debugger error: -debug flag must be followed by locahost:<port number>\n");
+    return false;
+  }
+
+  if (port < 0 || port > 0xffff) {
+    printf("debugger error: -debug port must be a value between 0-65535\n");
+    return false;
+  }
+
+  if ((gdb->socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
+    printf("debugger error: could create socket\n");
+    return false;
+  }
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  //addr.sin_addr.s_addr = IPADDR_ANY;
+  addr.sin_port = htons((unsigned short)port);
+
+  int flag = 1;  
+  if (-1 == setsockopt(gdb->socket, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag))) {
+    printf("debugger error: could not open port %d\n", (int)port);
+    return false;
+  }
+
+  if(bind(gdb->socket, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+    printf("debugger error: could not open port %d\n", (int)port);
+    return false;
+  }
+
+  if(listen(gdb->socket, 1) < 0) {
+    printf("debugger error: could not listen on port %d\n", (int)port);
+    return false;
+  }
+
+  printf("Waiting for gdb connection on port %d\n", (int)port);
+
+  if((gdb->client = accept(gdb->socket, NULL, NULL)) < 0) {
+    printf("debugger error: could not connect to client on port %d\n", (int)port);
+    return false;
+  }
+
+  gdb->device = device;
+  device_connect_debugger(device, gdb, &gdb_handle_breakpoint);
+
+  gdb->flags = GDB_FLAGS_INITIAL | GDB_FLAGS_CONNECTED;
+  vr4300_set_breakpoint(device->vr4300, 0xFFFFFFFF80000000ULL);
+
+  if (cen64_mutex_create(&gdb->client_mutex)) {
+    printf("Failed to create gdb client semaphore.\n");
+    return false;
+  }
+
+  if (cen64_cv_create(&gdb->client_semaphore)) {
+    cen64_mutex_destroy(&gdb->client_mutex);
+    printf("Failed to create gdb client semaphore.\n");
+    return false;
+  }
+
+  if (cen64_thread_create(&gdb->thread, gdb_thread, gdb)) {
+    cen64_mutex_destroy(&gdb->client_mutex);
+    cen64_cv_destroy(&gdb->client_semaphore);
+    printf("Failed to create gdb thread.\n");
+    return false;
+  }
+
+  return true;
+}
+
+cen64_cold void gdb_destroy(struct gdb* gdb) {
+  gdb->flags = 0;
+
+  shutdown(gdb->client, 2);
+  shutdown(gdb->socket, 2);
+
+  cen64_thread_join(&gdb->thread);
+  cen64_mutex_destroy(&gdb->client_mutex);
+  cen64_cv_destroy(&gdb->client_semaphore);
+
+  gdb->device = NULL;
+  free(gdb);
+}

--- a/gdb/gdb.h
+++ b/gdb/gdb.h
@@ -1,0 +1,42 @@
+//
+// gdb.h: gdb remote debugger implementation
+//
+// CEN64: Cycle-Accurate Nintendo 64 Emulator.
+// Copyright (C) 2015, Tyler J. Stachecki.
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+
+#ifndef _gdb_h__
+#define _gdb_h__
+#include "common.h"
+#include "vr4300/interface.h"
+#include "device/device.h"
+
+#define MAX_GDB_PACKET_SIZE     0x4000
+
+enum gdb_flags {
+    GDB_FLAGS_INITIAL = 0x1,
+    GDB_FLAGS_CONNECTED = 0x2,
+    GDB_FLAGS_PAUSED = 0x4,
+};
+
+struct gdb {
+    int socket;
+    int client;
+    struct cen64_device* device;
+    int pending_data;
+    char packet_buffer[MAX_GDB_PACKET_SIZE*2];
+    char output_buffer[MAX_GDB_PACKET_SIZE];
+    int flags;
+    cen64_thread thread;
+    cen64_mutex client_mutex;
+    cen64_cv client_semaphore;
+};
+
+cen64_cold struct gdb* gdb_alloc();
+cen64_cold bool gdb_init(struct gdb* gdb, struct cen64_device* device, const char* host);
+cen64_cold void gdb_destroy(struct gdb* gdb);
+
+#endif

--- a/gdb/gdb.md
+++ b/gdb/gdb.md
@@ -1,0 +1,91 @@
+
+# Debugging with GDB
+
+This is a short tutorial on how to use the cen64 debugger
+
+## Including Debugging Symbols
+
+When compiling your C source files you need to include debug symobls. Using using GCC, you do this with the -g flag
+
+```bash
+mips64-elf-cc -c -g -o src/boot.o src/boot.c
+```
+
+This will include debugging symbols into `src/boot.o`. You can verify debugging symbols have been included in the .o by attempting to load it into gdb using `gdb -q <path_to_.o>`
+
+This what it looks like when there are symbols
+```bash
+gdb -q src/boot.o
+Reading symbols from src/boot.o...
+(gdb) 
+```
+
+This is what it looks like when there are no symbols
+```bash
+gdb -q src/boot.o
+Reading symbols from src/boot.o...
+(No debugging symbols found in src/boot.o)
+(gdb) 
+```
+
+
+Next you need to make sure the symbols are preserved in the linking process. This is the default behavoir of `ln` but if you find that the `.o` files that result from the linking process don't contain debugging symbols then they may be getting stripped out. This could either be from the `-S` flag used as in input to the `ld` program in they are getting removed as part of the linker script. If you are using spicy, it is configured to remove symbols by default. My fork of [spicy](https://github.com/lambertjamesd/spicy) it will not strip debug symbols.
+
+The `.o` file generated from spicy or, if you aren't using spicy, the `.o` file used in `objcopy` to generate the rom file is the one you should load into gdb to get the symbols for the rom. `objcopy` should strip debugging symbols for you so there is no problem keeping them in during the final linker step.
+
+## Starting cen64 with the Debugger
+
+To start cen64 with the debugger, simply run it with the `-debug` flag.
+
+```
+cen64 -debug localhost:2345 pifdata.bin game.n64
+```
+
+This will cause cen64 to pause and listen on port `2345` for an incoming connection from gdb. It will not run until gdb has connected.
+
+## Connecting with GDB
+
+After you run cen64, you can then run and connect gdb to it. I found I had to use `gdb-multiarch` to get debugging with a MIPS processor to work. Before connecting to cen64 you need to start up gdb with the correct symbols
+
+```
+gdb-multiarch -q game.out
+```
+
+If everything worked you should see this
+
+```
+gdb-multiarch -q game.out
+Reading symbols from game.out...
+(gdb) 
+```
+
+You can then type the following command into gdb
+
+```
+target remote localhost:2354
+```
+
+If everything is working it should look like this.
+
+```
+(gdb) target remote localhost:8080
+Remote debugging using localhost:8080
+0x80000000 in ?? ()
+(gdb) 
+```
+
+At this point gdb is working and ready to go. The debugger is paused in the boot code. You can set breakpoints using the `break` command.
+
+This this example, main is the name of the entrypoint into the code.
+```
+break main
+``` 
+
+You can begin running your rom by using the command `c`.
+
+```
+c
+```
+
+This is not a tutorial on how to use gdb. If you need further help on how to debug you will have to look elsewhere. The recommened way to use this however is to find a gdb plugin for an IDE to handle the low level commands for you.
+

--- a/gdb/protocol.c
+++ b/gdb/protocol.c
@@ -1,0 +1,351 @@
+//
+// protocol.c: gdb message parsing and responding
+//
+// CEN64: Cycle-Accurate Nintendo 64 Emulator.
+// Copyright (C) 2015, Tyler J. Stachecki.
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+
+#include "gdb/protocol.h"
+#include "gdb/gdb.h"
+#include "vr4300/cpu.h"
+
+#include <inttypes.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <windows.h>
+#include <ws2tcpip.h>
+#else
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+#define GDB_GET_EXC_CODE(cause) (((cause) >> 2) & 0x1f)
+#define GDB_TRANSLATE_PC(pc)    ((uint64_t)(pc) | 0xFFFFFFFF00000000ULL)
+#define GDB_GLOBAL_THREAD_ID 1
+#define GDB_STR_STARTS_WITH(str, const_str) (strncmp(str, const_str, sizeof const_str - 1) == 0)
+
+static int gdb_signals[32] = {
+  2, // SIGINT
+  11, // SIGSEGV
+  11, // SIGSEGV
+  11, // SIGSEGV
+  11, // SIGSEGV
+  11, // SIGSEGV
+  10, // SIGBUS
+  10, // SIGBUS
+  12, // SIGSYS
+  5, // SIGTRAP
+  4, // SIGILL
+  30, // SIGUSR1
+  8, // SIGFPE
+  5, // SIGTRAP
+  0, // reserved
+  8, // SIGFPE
+  0, // reserved
+  0, // reserved
+  0, // reserved
+  0, // reserved
+  0, // reserved
+  0, // reserved
+  0, // reserved
+  5, // SIGTRAP
+  0, // reserved
+  0, // reserved
+  0, // reserved
+  0, // reserved
+  0, // reserved
+  0, // reserved
+  0, // reserved
+  0, // reserved
+};
+
+int gdb_read_hex_digit(char character) {
+  if (character >= 'a' && character <= 'f') {
+    return 10 + character - 'a';
+  } else if (character >= 'A' && character <= 'F') {
+    return 10 + character - 'A';
+  } else if (character >= '0' && character <= '9') {
+    return character - '0';
+  } else {
+    return -1;
+  }   
+}
+
+uint32_t gdb_parse_hex(const char* src, int max_bytes) {
+  uint32_t result = 0;
+  int current_char;
+  int max_characters = max_bytes * 2;
+
+  for (current_char = 0; current_char < max_characters; ++current_char) {
+    int digit = gdb_read_hex_digit(*src);
+
+    if (digit != -1) {
+      result = (result << 4) + digit;
+    } else {
+      break;
+    }
+
+    ++src;
+  }
+
+  return result;
+}
+
+static char gdb_hex_letters[16] = "0123456789abcdef";
+
+char* gdb_write_hex64(char* target, uint64_t data, int data_size) {
+  int shift = data_size * 8 - 4;
+
+  while (shift >= 0) {
+    *target++ = gdb_hex_letters[(data >> shift) & 0xF];
+    shift -= 4;
+  }
+
+  return target;
+}
+
+int gdb_apply_checksum(char* message) {
+    char* message_start = message;
+    if (*message == '$') {
+        ++message;
+    }
+    
+    unsigned char checksum = 0;
+    while (*message)
+    {
+        if (*message == '#') {
+            ++message;
+            break;
+        }
+
+        checksum += (unsigned char)*message;
+        ++message;
+    }
+
+    sprintf(message, "%02x", checksum);
+
+    return (message - message_start) + 2;
+}
+
+void gdb_send(struct gdb* gdb) {
+  int messageLen = gdb_apply_checksum(gdb->output_buffer);
+  send(gdb->client, gdb->output_buffer, messageLen, 0);
+  debug("send: %.*s\n", messageLen, gdb->output_buffer);
+}
+
+void gdb_send_literal(struct gdb* gdb, const char* message) {
+    send(gdb->client, message, strlen(message), 0);
+    debug("send: %s\n", message);
+}
+
+void gdb_handle_query(struct gdb* gdb, const char* command_start, const char *command_end) {
+  if (GDB_STR_STARTS_WITH(command_start, "qSupported")) {
+    strcpy(gdb->output_buffer, "$PacketSize=4000;vContSupported+;swbreak+#");
+    gdb_send(gdb);
+  } else if (GDB_STR_STARTS_WITH(command_start, "qTStatus")) {
+    gdb_send_literal(gdb, "$#00");
+  } else if (GDB_STR_STARTS_WITH(command_start, "qfThreadInfo")) {
+    sprintf(gdb->output_buffer, "$m%x#", GDB_GLOBAL_THREAD_ID);
+    gdb_send(gdb);
+  } else if (GDB_STR_STARTS_WITH(command_start, "qsThreadInfo")) {
+    strcpy(gdb->output_buffer, "$l#");
+    gdb_send(gdb);
+  } else if (GDB_STR_STARTS_WITH(command_start, "qAttached")) {
+    strcpy(gdb->output_buffer, "$0#");
+    gdb_send(gdb);
+  } else if (GDB_STR_STARTS_WITH(command_start, "qC")) {
+    sprintf(gdb->output_buffer, "$QC%x#", GDB_GLOBAL_THREAD_ID);
+    gdb_send(gdb);
+  } else if (GDB_STR_STARTS_WITH(command_start, "qTfV")) {
+    gdb_send_literal(gdb, "$#00");
+  } else if (GDB_STR_STARTS_WITH(command_start, "qTfP")) {
+    gdb_send_literal(gdb, "$#00");
+  } else if (GDB_STR_STARTS_WITH(command_start, "qOffsets")) {
+    sprintf(gdb->output_buffer, "$Text=%x;Data=%x;Bss=%x#", 0, 0, 0);
+    gdb_send(gdb);
+  } else if (GDB_STR_STARTS_WITH(command_start, "qSymbol")) {
+    gdb_send_literal(gdb, "$OK#9a");
+  } else if (GDB_STR_STARTS_WITH(command_start, "qThreadExtraInfo")) {
+    strcpy(gdb->output_buffer, "$746872656164#");
+    gdb_send(gdb);
+  } else {
+    gdb_send_literal(gdb, "$#00");
+  }
+}
+
+void gdb_handle_v(struct gdb* gdb, const char* command_start, const char *command_end) {
+  if (GDB_STR_STARTS_WITH(command_start, "vMustReplyEmpty")) {
+    gdb_send_literal(gdb, "$#00");
+  } else if (GDB_STR_STARTS_WITH(command_start, "vCont")) {
+    if (command_start[5] == '?') {
+      strcpy(gdb->output_buffer, "$c;t#");
+      gdb_send(gdb);
+    } else {
+      switch (command_start[6])
+      {
+        case 'c':
+          cen64_cv_signal(&gdb->client_semaphore);
+          break;
+        case 't':
+          vr4300_signal_break(gdb->device->vr4300);
+          break;
+      }
+    }
+  } else if (GDB_STR_STARTS_WITH(command_start, "vKill")) {
+    gdb->flags &= ~GDB_FLAGS_CONNECTED;
+    gdb->flags &= ~GDB_FLAGS_PAUSED;
+    cen64_cv_signal(&gdb->client_semaphore);
+    gdb_send_literal(gdb, "$OK#9a");
+  } else {
+    gdb_send_literal(gdb, "$#00");
+  }
+}
+
+void gdb_reply_registers(struct gdb* gdb) {
+  char* current = gdb->output_buffer;
+  *current++ = '$';
+
+  // R0
+  current = gdb_write_hex64(current, 0, sizeof(uint64_t));
+  for (int i = VR4300_REGISTER_AT; i <= VR4300_REGISTER_RA; i++) {
+    current = gdb_write_hex64(current, vr4300_get_register(gdb->device->vr4300, i), sizeof(uint64_t));
+  }
+
+  current = gdb_write_hex64(current, vr4300_get_register(gdb->device->vr4300, VR4300_CP0_REGISTER_STATUS), sizeof(uint64_t));
+  current = gdb_write_hex64(current, vr4300_get_register(gdb->device->vr4300, VR4300_REGISTER_LO), sizeof(uint64_t));
+  current = gdb_write_hex64(current, vr4300_get_register(gdb->device->vr4300, VR4300_REGISTER_HI), sizeof(uint64_t));
+  current = gdb_write_hex64(current, vr4300_get_register(gdb->device->vr4300, VR4300_CP0_REGISTER_BADVADDR), sizeof(uint64_t));
+  current = gdb_write_hex64(current, vr4300_get_register(gdb->device->vr4300, VR4300_CP0_REGISTER_CAUSE), sizeof(uint64_t));
+  current += sprintf(current, "%08x%08x", 0, (int32_t)vr4300_get_pc(gdb->device->vr4300));
+
+  for (int i = VR4300_REGISTER_CP1_0; i <= VR4300_REGISTER_CP1_31; i++) {
+    current = gdb_write_hex64(current, vr4300_get_register(gdb->device->vr4300, i), sizeof(uint64_t));
+  }
+
+  current = gdb_write_hex64(current, vr4300_get_register(gdb->device->vr4300, VR4300_CP1_FCR31), sizeof(uint64_t));
+
+  *current++ = '#';
+  *current++ = '\0';
+
+  gdb_send(gdb);
+}
+
+void gdb_reply_memory(struct gdb* gdb, const char* command_start, const char *command_end) {
+  char* current = gdb->output_buffer;
+  *current++ = '$';
+
+  const char* len_text = command_start + 1;
+
+  while (*len_text != ',' && len_text != command_end) {
+      ++len_text;
+  }
+
+  int32_t addr = gdb_parse_hex(command_start + 1, 4);
+  int32_t len = gdb_parse_hex(len_text + 1, 4);
+
+  int32_t alignedAddr = addr & ~0x3;
+  int32_t byteShift = addr - alignedAddr;
+    
+  for (int curr = 0; curr < len + byteShift; curr += 4) {
+    uint32_t word = 0;
+    int32_t vaddr = alignedAddr + curr;
+    
+    if (!vr4300_read_word_vaddr(gdb->device->vr4300, vaddr, &word)) {
+      debug("Bad vaddr %08x\n", vaddr);
+    }
+
+    // if (curr > 0x20) {
+    //   word = curr;
+    // }
+
+    current = gdb_write_hex64(current, word, sizeof(uint32_t));
+  }
+
+  if (byteShift) {
+    for (int curr = 0; curr < len * 2; curr++) {
+      gdb->output_buffer[curr + 1] = gdb->output_buffer[curr + 1 + byteShift * 2];
+    }
+  }
+
+  current = gdb->output_buffer + 1 + len * 2;
+
+  *current++ = '#';
+  *current++ = '\0';
+
+  gdb_send(gdb);
+}
+
+void gdb_handle_packet(struct gdb* gdb, const char* command_start, const char* command_end) {
+  switch (*command_start) {
+    case 'q':
+      gdb_handle_query(gdb, command_start, command_end);
+      break;
+    case 'v':
+      gdb_handle_v(gdb, command_start, command_end);
+      break;
+    case 'H':
+      gdb_send_literal(gdb, "$OK#9a");
+      break;
+    case '!':
+      gdb_send_literal(gdb, "$#00");
+      break;
+    case '?':
+      gdb_send_stop_reply(gdb, false);
+      break;
+    case 'g':
+      gdb_reply_registers(gdb);
+      break;
+    case 'm':
+      gdb_reply_memory(gdb, command_start, command_end);
+      break;
+    case 'D':
+      gdb->flags &= ~GDB_FLAGS_CONNECTED;
+      gdb_send_literal(gdb, "$OK#9a");;
+      break;
+    case 'z':
+    case 'Z':
+    {
+      if (command_start[1] == '0') {
+        uint64_t addr = GDB_TRANSLATE_PC(gdb_parse_hex(&command_start[3], 4));
+
+        if (*command_start == 'z') {
+          vr4300_remove_breakpoint(gdb->device->vr4300, addr);
+        } else {
+          vr4300_set_breakpoint(gdb->device->vr4300, addr);
+        }
+
+        return gdb_send_literal(gdb, "$OK#9a");
+      } else {
+        gdb_send_literal(gdb, "$#00");
+      }
+      break;
+    }
+    default:
+      gdb_send_literal(gdb, "$#00");
+  }
+}
+
+cen64_cold void gdb_send_stop_reply(struct gdb* gdb, bool is_breakpoint) {
+  char* current = gdb->output_buffer;
+  int exc_code;
+
+  if (is_breakpoint) {
+    exc_code = 9;
+  } else {
+    exc_code = GDB_GET_EXC_CODE(vr4300_get_register(gdb->device->vr4300, VR4300_CP0_REGISTER_CAUSE));
+  }
+  current += sprintf(current, "$T%02x", gdb_signals[exc_code]);
+  if (is_breakpoint) {
+    current += sprintf(current, "swbreak:");
+  }
+  current += sprintf(current, "thread:%d;", GDB_GLOBAL_THREAD_ID);
+  *current++ = '#';
+  *current++ = '\0';
+  gdb_send(gdb);
+}

--- a/gdb/protocol.h
+++ b/gdb/protocol.h
@@ -1,0 +1,21 @@
+//
+// protocol.h: gdb message parsing and responding
+//
+// CEN64: Cycle-Accurate Nintendo 64 Emulator.
+// Copyright (C) 2015, Tyler J. Stachecki.
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+
+#ifndef _gdb_protocol_h__
+#define _gdb_protocol_h__
+#include "common.h"
+
+struct gdb;
+
+cen64_cold void gdb_send_stop_reply(struct gdb* gdb, bool is_breakpoint);
+cen64_cold void gdb_handle_packet(struct gdb* gdb, const char* command_start, const char* command_end);
+
+
+#endif

--- a/vr4300/cpu.c
+++ b/vr4300/cpu.c
@@ -70,6 +70,8 @@ int vr4300_init(struct vr4300 *vr4300, struct bus_controller *bus, bool profilin
   else
     vr4300->profile_samples = NULL;
 
+  vr4300_debug_init(&vr4300->debug);
+
   return 0;
 }
 
@@ -126,11 +128,23 @@ void vr4300_print_summary(struct vr4300_stats *stats) {
 }
 
 uint64_t vr4300_get_register(struct vr4300 *vr4300, size_t i) {
-    return vr4300->regs[i];
+  return vr4300->regs[i];
 }
 
 uint64_t vr4300_get_pc(struct vr4300 *vr4300) {
-    return vr4300->pipeline.dcwb_latch.common.pc;
+  return vr4300->pipeline.dcwb_latch.common.pc;
+}
+
+cen64_cold void vr4300_signal_break(struct vr4300 *vr4300) {
+  vr4300_debug_signal(&vr4300->debug, VR4300_DEBUG_SIGNALS_BREAK);
+}
+
+cen64_cold void vr4300_set_breakpoint(struct vr4300 *vr4300, uint64_t at) {
+  vr4300_debug_set_breakpoint(&vr4300->debug, at);
+}
+
+cen64_cold void vr4300_remove_breakpoint(struct vr4300 *vr4300, uint64_t at) {
+  vr4300_debug_remove_breakpoint(&vr4300->debug, at);
 }
 
 struct vr4300* vr4300_alloc() {
@@ -140,6 +154,7 @@ struct vr4300* vr4300_alloc() {
 }
 
 cen64_cold void vr4300_free(struct vr4300* ptr) {
+    vr4300_debug_cleanup(&ptr->debug);
     free(ptr);
 }
 
@@ -151,4 +166,9 @@ cen64_cold struct vr4300_stats* vr4300_stats_alloc() {
 
 cen64_cold void vr4300_stats_free(struct vr4300_stats* ptr) {
     free(ptr);
+}
+
+cen64_cold void vr4300_connect_debugger(struct vr4300 *vr4300, void* break_handler_data, vr4300_debug_break_handler break_handler) {
+  vr4300->debug.break_handler = break_handler;
+  vr4300->debug.break_handler_data = break_handler_data;
 }

--- a/vr4300/cpu.h
+++ b/vr4300/cpu.h
@@ -14,7 +14,9 @@
 #include "vr4300/cp0.h"
 #include "vr4300/cp1.h"
 #include "vr4300/dcache.h"
+#include "vr4300/debug.h"
 #include "vr4300/icache.h"
+#include "vr4300/interface.h"
 #include "vr4300/opcodes.h"
 #include "vr4300/pipeline.h"
 
@@ -23,6 +25,7 @@ struct bus_controller;
 enum vr4300_signals {
   VR4300_SIGNAL_FORCEEXIT = 0x000000001,
   VR4300_SIGNAL_COLDRESET = 0x000000002,
+  VR4300_SIGNAL_BREAK = 0x000000004,
 };
 
 enum vr4300_register {
@@ -103,6 +106,8 @@ struct vr4300 {
   struct vr4300_icache icache;
 
   uint64_t *profile_samples;
+
+  struct vr4300_debug debug;
 };
 
 struct vr4300_stats {
@@ -112,7 +117,6 @@ struct vr4300_stats {
   unsigned long opcode_counts[NUM_VR4300_OPCODES];
 };
 
-cen64_cold int vr4300_init(struct vr4300 *vr4300, struct bus_controller *bus, bool profiling);
 cen64_cold void vr4300_print_summary(struct vr4300_stats *stats);
 
 cen64_flatten cen64_hot void vr4300_cycle_(struct vr4300 *vr4300);

--- a/vr4300/debug.c
+++ b/vr4300/debug.c
@@ -1,0 +1,55 @@
+//
+// vr4300/debug.c: VR4300 debug hooks.
+//
+// CEN64: Cycle-Accurate Nintendo 64 Emulator.
+// Copyright (C) 2015, Tyler J. Stachecki.
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+
+#include "debug.h"
+
+cen64_cold void vr4300_debug_init(struct vr4300_debug* debug) {
+  hash_table_init(&debug->breakpoints, 0);
+  debug->break_handler = NULL;
+  debug->break_handler_data = NULL;
+}
+
+cen64_cold void vr4300_debug_cleanup(struct vr4300_debug* debug) {
+  hash_table_free(&debug->breakpoints);
+}
+
+cen64_cold void vr4300_debug_check_breakpoints(struct vr4300_debug* debug, uint64_t pc) {
+  if (debug->break_handler) {
+    enum vr4300_debug_break_reason reason = VR4300_DEBUG_BREAK_REASON_NONE;
+    if (hash_table_get(&debug->breakpoints, (unsigned long)pc, NULL)) {
+      reason = VR4300_DEBUG_BREAK_REASON_BREAKPOINT;
+    } else if (debug->signals & VR4300_DEBUG_SIGNALS_BREAK) {
+      reason = VR4300_DEBUG_BREAK_REASON_PAUSE;
+    }
+    
+    if (reason != VR4300_DEBUG_BREAK_REASON_NONE) {
+      debug->signals &= ~VR4300_DEBUG_SIGNALS_BREAK;
+      debug->break_handler(debug->break_handler_data, reason);
+    }
+  }
+}
+
+cen64_cold void vr4300_debug_exception(struct vr4300_debug* debug) {
+  if (debug->break_handler) {
+    debug->break_handler(debug->break_handler_data, VR4300_DEBUG_BREAK_REASON_EXCEPTION);
+  }
+}
+
+cen64_cold void vr4300_debug_set_breakpoint(struct vr4300_debug* debug, uint64_t pc) {
+  hash_table_set(&debug->breakpoints, (unsigned long)pc, 1);
+}
+
+cen64_cold void vr4300_debug_remove_breakpoint(struct vr4300_debug* debug, uint64_t pc) {
+  hash_table_delete(&debug->breakpoints, (unsigned long)pc);
+}
+
+cen64_cold void vr4300_debug_signal(struct vr4300_debug* debug, enum vr4300_debug_signals signal) {
+  debug->signals |= signal;
+}

--- a/vr4300/debug.h
+++ b/vr4300/debug.h
@@ -1,0 +1,38 @@
+//
+// vr4300/debug.h: VR4300 debug hooks.
+//
+// CEN64: Cycle-Accurate Nintendo 64 Emulator.
+// Copyright (C) 2015, Tyler J. Stachecki.
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+
+#ifndef __vr4300_debug_h__
+#define __vr4300_debug_h__
+#include "common.h"
+#include "common/hash_table.h"
+#include "vr4300/interface.h"
+
+enum vr4300_debug_signals {
+  VR4300_DEBUG_SIGNALS_BREAK  = 0x000000001,
+};
+
+struct vr4300_debug {
+    struct hash_table breakpoints;
+    vr4300_debug_break_handler break_handler;
+    void* break_handler_data;
+    unsigned signals;
+};
+
+cen64_cold void vr4300_debug_init(struct vr4300_debug* debug);
+
+cen64_cold void vr4300_debug_cleanup(struct vr4300_debug* debug);
+cen64_cold void vr4300_debug_check_breakpoints(struct vr4300_debug* debug, uint64_t pc);
+cen64_cold void vr4300_debug_exception(struct vr4300_debug* debug);
+cen64_cold void vr4300_debug_set_breakpoint(struct vr4300_debug* debug, uint64_t pc);
+cen64_cold void vr4300_debug_remove_breakpoint(struct vr4300_debug* debug, uint64_t pc);
+
+cen64_cold void vr4300_debug_signal(struct vr4300_debug* debug, enum vr4300_debug_signals signal);
+
+#endif

--- a/vr4300/fault.c
+++ b/vr4300/fault.c
@@ -483,6 +483,7 @@ void VR4300_BRPT(struct vr4300 *vr4300) {
   vr4300_exception_prolog(vr4300, common, &cause, &status, &epc);
   vr4300_exception_epilogue(vr4300, (cause & ~0xFF) | (9 << 2),
     status, epc, 0x180);
+  vr4300_debug_exception(&vr4300->debug);
 }
 
 // TRAP: Trap exception
@@ -495,6 +496,7 @@ void VR4300_TRAP(struct vr4300* vr4300) {
   vr4300_exception_prolog(vr4300, common, &cause, &status, &epc);
   vr4300_exception_epilogue(vr4300, (cause & ~0xFF) | (13 << 2),
     status, epc, 0x180);
+  vr4300_debug_exception(&vr4300->debug);
 }
 
 // RI: Reserved Instruction exception
@@ -521,5 +523,6 @@ void VR4300_WAT(struct vr4300 *vr4300) {
     status, epc, 0x180);
 
   vr4300_dc_fault(vr4300, VR4300_FAULT_WAT);
+  vr4300_debug_exception(&vr4300->debug);
 }
 

--- a/vr4300/interface.h
+++ b/vr4300/interface.h
@@ -24,6 +24,15 @@ enum rcp_interrupt_mask {
 struct vr4300;
 struct vr4300_stats;
 
+enum vr4300_debug_break_reason {
+  VR4300_DEBUG_BREAK_REASON_NONE,
+  VR4300_DEBUG_BREAK_REASON_BREAKPOINT,
+  VR4300_DEBUG_BREAK_REASON_EXCEPTION,
+  VR4300_DEBUG_BREAK_REASON_PAUSE,
+};
+
+typedef void (*vr4300_debug_break_handler)(void* data, enum vr4300_debug_break_reason reason);
+
 cen64_cold struct vr4300* vr4300_alloc();
 cen64_cold void vr4300_free(struct vr4300*);
 
@@ -39,6 +48,8 @@ cen64_cold void vr4300_cycle_extra(struct vr4300 *vr4300, struct vr4300_stats *s
 uint64_t vr4300_get_register(struct vr4300 *vr4300, size_t i);
 uint64_t vr4300_get_pc(struct vr4300 *vr4300);
 
+bool vr4300_read_word_vaddr(struct vr4300 *vr4300, uint64_t vaddr, uint32_t* result);
+
 int read_mi_regs(struct vr4300 *vr4300, uint32_t address, uint32_t *word);
 int write_mi_regs(struct vr4300 *vr4300, uint32_t address, uint32_t word, uint32_t dqm);
 
@@ -50,6 +61,11 @@ void signal_dd_interrupt(struct vr4300 *vr4300);
 
 uint64_t get_profile_sample(struct vr4300 const *vr4300, size_t i);
 int has_profile_samples(struct vr4300 const *vr4300);
+
+cen64_cold void vr4300_signal_break(struct vr4300 *vr4300);
+cen64_cold void vr4300_set_breakpoint(struct vr4300 *vr4300, uint64_t at);
+cen64_cold void vr4300_remove_breakpoint(struct vr4300 *vr4300, uint64_t at);
+cen64_cold void vr4300_connect_debugger(struct vr4300 *vr4300, void* break_handler_data, vr4300_debug_break_handler break_handler);
 
 #endif
 

--- a/vr4300/pipeline.c
+++ b/vr4300/pipeline.c
@@ -522,6 +522,8 @@ void vr4300_cycle_(struct vr4300 *vr4300) {
     if (vr4300_wb_stage(vr4300))
       return;
 
+    vr4300_debug_check_breakpoints(&vr4300->debug, vr4300_get_pc(vr4300));
+
     if (vr4300_dc_stage(vr4300))
       return;
 


### PR DESCRIPTION
This PR aims to implement a remote debugger into cen64
https://github.com/n64dev/cen64/issues/87

It first implements breakpoint handling into the core cen64 device, independent of this specific gdb implementation. This will allow the option for other debuggers in the future. 

I then implement the gdb protocol on top of the cen64 device. To use it, you just need to use the already present but unused `-debug` flag 
```
cen64 -debug localhost:2345 pifdata.bin rom.n64
```
This will open the cen64 window but will not run the rom until a debugger has been connected. A temporary breakpoint is automatically set at address 0x80000000

```
gdb-multiarch -q game.out
Reading symbols from game.out...
(gdb) target remote localhost:2345
Remote debugging using localhost:2345
0x80000000 in ?? ()
(gdb) 
> 