### PR TITLE
Feature: Mupen64 movie file playback

### DIFF
--- a/cen64.c
+++ b/cen64.c
@@ -53,6 +53,8 @@ int cen64_main(int argc, const char **argv) {
   struct save_file flashram;
   struct is_viewer is, *is_in = NULL;
 
+  FILE* m64_fp = NULL;
+
   if (!cart_db_is_well_formed()) {
     printf("Internal cart detection database is not well-formed.\n");
     return EXIT_FAILURE;
@@ -180,6 +182,30 @@ int cen64_main(int argc, const char **argv) {
     }
   }
 
+  if (options.m64_path) {
+    m64_fp = fopen(options.m64_path, "rb");
+    if (m64_fp != NULL) {
+      // http://tasvideos.org/EmulatorResources/Mupen/M64.html
+      uint8_t header[0x400];
+      size_t n = fread(header, 1, sizeof header, m64_fp);
+      if (n == sizeof header && memcmp(header, "M64\x1A", 4) == 0) {
+        printf("Playing back m64:\n");
+        printf("  ROM name: %.32s (crc %X, region %X)\n",
+               header+0xC4,
+               *(uint32_t*)(header+0xE4),
+               *(uint16_t*)(header+0xE8));
+        printf("  Author: %.222s\n", header+0x222);
+        printf("  Description: %.256s\n", header+0x300);
+      } else {
+        fclose(m64_fp);
+        printf("Invalid Mupen64 movie file '%s'.\n", options.m64_path);
+        return EXIT_FAILURE;
+      }
+    } else {
+      printf("Failed to open Mupen64 movie file '%s'.\n", options.m64_path);
+      return EXIT_FAILURE;
+    }
+  }
 
 
   // Allocate memory for and create the device.
@@ -193,7 +219,7 @@ int cen64_main(int argc, const char **argv) {
 
     if (device_create(device, &ddipl, dd_variant, &ddrom,
       &pifrom, &cart, &eeprom, &sram,
-      &flashram, is_in, controller,
+      &flashram, is_in, controller, m64_fp,
       options.no_audio, options.no_video, options.enable_profiling) == NULL) {
       printf("Failed to create a device.\n");
       status = EXIT_FAILURE;

--- a/device/device.c
+++ b/device/device.c
@@ -44,7 +44,7 @@ struct cen64_device *device_create(struct cen64_device *device,
   const struct rom_file *pifrom, const struct rom_file *cart,
   const struct save_file *eeprom, const struct save_file *sram,
   const struct save_file *flashram, struct is_viewer *is,
-  const struct controller *controller,
+  const struct controller *controller, FILE* m64_fp,
   bool no_audio, bool no_video, bool profiling) {
 
   // Allocate memory for VR4300
@@ -99,7 +99,7 @@ struct cen64_device *device_create(struct cen64_device *device,
   // Initialize the SI.
   if (si_init(&device->si, &device->bus, pifrom->ptr,
     cart->ptr, dd_variant, eeprom->ptr, eeprom->size,
-    controller)) {
+    controller, m64_fp)) {
     debug("create_device: Failed to initialize the SI.\n");
     return NULL;
   }
@@ -159,6 +159,10 @@ void device_destroy(struct cen64_device *device, const char *cart_path) {
     }
 
     fclose(f);
+  }
+
+  if (device->si.m64_fp != NULL) {
+    fclose(device->si.m64_fp);
   }
 }
 

--- a/device/device.h
+++ b/device/device.h
@@ -61,7 +61,7 @@ cen64_cold struct cen64_device *device_create(struct cen64_device *device,
   const struct rom_file *pifrom, const struct rom_file *cart,
   const struct save_file *eeprom, const struct save_file *sram,
   const struct save_file *flashram, struct is_viewer *is,
-  const struct controller *controller,
+  const struct controller *controller, FILE* m64_fp,
   bool no_audio, bool no_video, bool profiling);
 
 cen64_cold void device_exit(struct bus_controller *bus);

--- a/device/options.c
+++ b/device/options.c
@@ -26,6 +26,7 @@ const struct cen64_options default_cen64_options = {
   NULL, // flashram_path
   0,    // is_viewer_present
   NULL, // controller
+  NULL, // m64_path
 #ifdef _WIN32
   false, // console
 #endif
@@ -151,6 +152,15 @@ int parse_options(struct cen64_options *options, int argc, const char *argv[]) {
       }
 
       options->controller[num] = opt;
+    }
+
+    else if (!strcmp(argv[i], "-m64")) {
+      if ((i + 1) >= (argc - 1)) {
+        printf("-m64 requires a path to the movie file.\n\n");
+        return 1;
+      }
+
+      options->m64_path = argv[++i];
     }
 
     // TODO: Handle this better.
@@ -282,6 +292,8 @@ void print_command_line_usage(const char *invokation_string) {
       "  -sram <path>               : Path to SRAM save.\n"
       "  -flash <path>              : Path to FlashRAM save.\n"
       "    For mempak see controller options.\n"
+      "Mupen64 movie playback options:\n"
+      "  -m64 <path>                : Path to m64 movie file.\n"
 
     ,invokation_string
   );

--- a/device/options.h
+++ b/device/options.h
@@ -27,6 +27,8 @@ struct cen64_options {
 
   struct controller *controller;
 
+  const char* m64_path;
+
 #ifdef _WIN32
   bool console;
 #endif

--- a/si/controller.h
+++ b/si/controller.h
@@ -41,13 +41,16 @@ struct si_controller {
   uint8_t input[4];
   struct eeprom eeprom;
   struct controller controller[4];
+
+  FILE* m64_fp; // Mupen64 movie file
 };
 
 cen64_cold int si_init(struct si_controller *si, struct bus_controller *bus,
   const uint8_t *pif_rom, const uint8_t *cart_rom,
   const struct dd_variant *dd_variant,
   uint8_t *eeprom, size_t eeprom_size,
-  const struct controller *controller);
+  const struct controller *controller,
+  FILE* m64_fp);
 
 int read_pif_rom_and_ram(void *opaque, uint32_t address, uint32_t *word);
 int write_pif_rom_and_ram(void *opaque, uint32_t address, uint32_t word, uint32_t dqm);


### PR DESCRIPTION
This pull request adds an optional feature to play back Mupen64 movies from game start.
Mupen64 movies are used to create Tool-Assisted Speedruns (TASes). For more information on what a TAS is, go here: http://tasvideos.org/WelcomeToTASVideos.html. For an example of an N64 TAS: http://tasvideos.org/3264M.html.

In the context of the Nintendo 64, various TASing communities use Mupen64, most prominently (but not exclusively), Super Mario 64 TASers. A very nice feature of the M64 movie format compared to other N64 TASing emulators is that it records the inputs when the game actually polls the controller, as opposed to recording the input for each visual frame. This means that TASes in this format can be played back on console despite the different lag timing in HLE emulators and real N64s, using specific hardware devices made for this purpose (for example, see https://www.youtube.com/watch?v=BFBGWrGT1E8).

One interesting aspect of SM64 TASes is that sometimes, certain techniques are used to save time that can crash on real hardware if done improperly, so console verification is important for these kinds of movies. One such example of a trick would be moneybag duplication, which can result in an RCP crash due to too many objects on screen causing a buffer overflow in the game's internal display list buffer which ends up sending invalid F3D commands (https://www.youtube.com/watch?v=sE_aLqwIva0, notice the black squares, those graphical glitches are indicative of a crash on real hardware, but the reverse is not true: this kind of bug can crash on real hardware without displaying any graphical anomalies on emulator, so that's not a reliable indicator). HLE emulators and video plugins fail to emulate this type of crash, but cen64 crashes just like a real N64 would. Therefore it is convenient to be able to validate TASes to ensure that they work on real hardware using an accurate emulator like cen64, because having a hardware TAS playback device is not accessible for most people.

The PR adds a command-line option to play back a movie file like so: `cen64 -m64 1KeyTas.m64 pifdata.bin SM64-JP.z64`. It only supports playing back movies from console reset, since savestates aren't implemented. This is the preferred method anyway, because savestates can't be used for console verification.

The interesting bit of code is in `si/controller.c:155`, which just copies the inputs stored in the M64 file to the SI controller verbatim during a PIF read command.