### PR TITLE
vr4300: fix badvaddr register in TLB exceptions.

### DIFF
--- a/vr4300/functions.c
+++ b/vr4300/functions.c
@@ -1209,7 +1209,7 @@ cen64_hot int VR4300_LOAD_STORE(struct vr4300 *vr4300,
   unsigned lshiftamt = (3 - request_size) << 3;
   unsigned rshiftamt = (address & 0x3) << 3;
 
-  exdc_latch->request.vaddr = address & ~(sel_mask & 0x3);
+  exdc_latch->request.vaddr = address;
   exdc_latch->request.data = dqm | (sel_mask & ((rt << lshiftamt) >> rshiftamt));
   exdc_latch->request.wdqm = ((uint32_t) sel_mask << lshiftamt) >> rshiftamt;
   exdc_latch->request.postshift = 0;
@@ -1529,7 +1529,7 @@ int VR4300_SDL_SDR(struct vr4300 *vr4300,
     dqm = mask >> shiftamt;
   }
 
-  exdc_latch->request.vaddr = address & ~0x3ULL;
+  exdc_latch->request.vaddr = address;
   exdc_latch->request.data = data;
   exdc_latch->request.wdqm = dqm;
   exdc_latch->request.access_type = VR4300_ACCESS_DWORD;
@@ -1568,7 +1568,7 @@ int VR4300_SWL_SWR(struct vr4300 *vr4300,
     dqm = mask >> shiftamt;
   }
 
-  exdc_latch->request.vaddr = address & ~0x3ULL;
+  exdc_latch->request.vaddr = address;
   exdc_latch->request.data = data;
   exdc_latch->request.wdqm = dqm;
   exdc_latch->request.access_type = VR4300_ACCESS_WORD;


### PR DESCRIPTION
Currently, all load/store opcodes (with the exception of LWL/LWR) mask
the lowest bit of address that causes a TLB exception in the BADVADDR
COP0 register. This is wrong because the VR4300 reports the exact
faulting address in that register, the reason being that the exception
handler must require it.

This is an example using libdragon:

```
#include <libdragon.h>

uint32_t *crasher = (uint32_t*)0x7;

int main() {
	init_interrupts();
	*crasher = 1;
}
```

Before:
<img width="668" alt="Schermata 2021-05-04 alle 00 18 43" src="https://user-images.githubusercontent.com/1014109/116940685-96202080-ac6e-11eb-8de4-288cd8ed2e89.png">

After:
<img width="668" alt="Schermata 2021-05-04 alle 00 19 00" src="https://user-images.githubusercontent.com/1014109/116940694-99b3a780-ac6e-11eb-9263-40f2781d9224.png">



