### PR TITLE
Fix two bugs in COP0 count

### DIFF
--- a/vr4300/cp0.c
+++ b/vr4300/cp0.c
@@ -92,6 +92,9 @@ int VR4300_DMTC0(struct vr4300 *vr4300,
 
   switch (dest + VR4300_REGISTER_CP0_0)
   {
+    case VR4300_CP0_REGISTER_COUNT:
+      rt <<= 1;
+      break;
     case VR4300_CP0_REGISTER_CAUSE:
       vr4300->regs[VR4300_CP0_REGISTER_CAUSE] &= ~0x0300;
       vr4300->regs[VR4300_CP0_REGISTER_CAUSE] |= rt & 0x0300;
@@ -193,6 +196,9 @@ int VR4300_MTC0(struct vr4300 *vr4300,
 
   switch (dest + VR4300_REGISTER_CP0_0)
   {
+    case VR4300_CP0_REGISTER_COUNT:
+      rt <<= 1;
+      break;
     case VR4300_CP0_REGISTER_CAUSE:
       vr4300->regs[VR4300_CP0_REGISTER_CAUSE] &= ~0x0300;
       vr4300->regs[VR4300_CP0_REGISTER_CAUSE] |= (int32_t)rt & 0x0300;

--- a/vr4300/cpu.c
+++ b/vr4300/cpu.c
@@ -30,16 +30,18 @@ void vr4300_cycle(struct vr4300 *vr4300) {
   // Increment counters.
   vr4300->regs[VR4300_CP0_REGISTER_COUNT]++;
 
-  if ((uint32_t) (vr4300->regs[VR4300_CP0_REGISTER_COUNT] >> 1) ==
-    (uint32_t) vr4300->regs[VR4300_CP0_REGISTER_COMPARE])
-    vr4300->regs[VR4300_CP0_REGISTER_CAUSE] |= 0x8000;
-
   // We're stalling for something...
   if (pipeline->cycles_to_stall > 0)
     pipeline->cycles_to_stall--;
 
   else
     vr4300_cycle_(vr4300);
+
+  if ((vr4300->regs[VR4300_CP0_REGISTER_COUNT] & 1) == 1 &&
+    (uint32_t) (vr4300->regs[VR4300_CP0_REGISTER_COUNT] >> 1) ==
+    (uint32_t) vr4300->regs[VR4300_CP0_REGISTER_COMPARE]) {
+    vr4300->regs[VR4300_CP0_REGISTER_CAUSE] |= 0x8000;
+  }
 }
 
 // Sets the opaque pointer used for external accesses.


### PR DESCRIPTION
First, since the internal register is kept in CPU cycles (not RCP cycles),
we need to double the value written via MTC0/DMTC0.

Second, writing a count equal to compare would cause an infinite loop
because the fault would be triggered while PC was on the instruction
doing MTC0 itself, which would be then re-executed at the end of the
exception. On real hardware, in general, when COUNT==COMPARE, the
interrupt happens a few cycles later, enough for PC to move to other
opcodes. Instead of trying to implement this, I've simply made sure
that the interrupt happened after the opcode was executed rather than
before. Also, since the internal counter is in CPU cycles, we make
sure to only raise the CAUSE bit once.

Attached is libdragon test ROM which stops in an infinite loop on
current master, and works after this PR.

[testrom_emu.zip](https://github.com/n64dev/cen64/files/6643627/testrom_emu.zip)
