### PR TITLE
Fix EEPROM detection Joybus status response

### DIFF
--- a/si/controller.c
+++ b/si/controller.c
@@ -122,13 +122,26 @@ int pif_perform_command(struct si_controller *si,
           break;
 
         case 4:
-          // XXX hack alert: this returns 16k EEPROM in the case of a
-          // 16k EEPROM and returns 4k EEPROM in all other cases. This
-          // is likely a hack to make games that expect EEPROM work,
-          // even if the user doesn't supply one on the command line.
-          recv_buf[0] = 0x00;
-          recv_buf[1] = si->eeprom.size == 0x800 ? 0xC0 : 0x80;
-          recv_buf[2] = 0x00;
+          switch (si->eeprom.size) {
+            case 0: // No EEPROM present
+              recv_buf[0] = 0xFF;
+              recv_buf[1] = 0xFF;
+              recv_buf[2] = 0xFF;
+              break;
+            case 0x200: // 4 kbit EEPROM
+              recv_buf[0] = 0x00;
+              recv_buf[1] = 0x80;
+              recv_buf[2] = 0x00;
+              break;
+            case 0x800: // 16 kbit EEPROM
+              recv_buf[0] = 0x00;
+              recv_buf[1] = 0xC0;
+              recv_buf[2] = 0x00;
+              break;
+            default: // Invalid EEPROM size
+              assert(0 && "Invalid EEPROM size.");
+              return 1;
+          }
           break;
 
         default:

--- a/si/controller.c
+++ b/si/controller.c
@@ -177,48 +177,60 @@ int pif_perform_command(struct si_controller *si,
 
     // Read from controller pak
     case 0x02:
-      if (channel < 4)
-        return controller_pak_read(&si->controller[channel],
-            send_buf, send_bytes, recv_buf, recv_bytes);
-      else
+      if (channel > 3) {
         assert(0 && "Invalid channel for controller pak read");
+        return 1;
+      }
+      return controller_pak_read(&si->controller[channel],
+        send_buf, send_bytes, recv_buf, recv_bytes);
 
     // Write to controller pak
     case 0x03:
-      if (channel < 4)
-        return controller_pak_write(&si->controller[channel],
-            send_buf, send_bytes, recv_buf, recv_bytes);
-      else
+      if (channel > 3) {
         assert(0 && "Invalid channel for controller pak write");
+        return 1;
+      }
+      return controller_pak_write(&si->controller[channel],
+        send_buf, send_bytes, recv_buf, recv_bytes);
 
     // EEPROM read
     case 0x04:
-      if (channel != 4)
+      if (channel != 4) {
         assert(0 && "Invalid channel for EEPROM read");
+        return 1;
+      }
       return eeprom_read(&si->eeprom, send_buf, send_bytes, recv_buf, recv_bytes);
 
     // EEPROM write
     case 0x05:
-      if (channel != 4)
+      if (channel != 4) {
         assert(0 && "Invalid channel for EEPROM write");
+        return 1;
+      }
       return eeprom_write(&si->eeprom, send_buf, send_bytes, recv_buf, recv_bytes);
 
     // RTC status
     case 0x06:
-      if (channel != 4)
+      if (channel != 4) {
         assert(0 && "Invalid channel for RTC status");
+        return 1;
+      }
       return rtc_status(send_buf, send_bytes, recv_buf, recv_bytes);
 
     // RTC read
     case 0x07:
-      if (channel != 4)
+      if (channel != 4) {
         assert(0 && "Invalid channel for RTC read");
+        return 1;
+      }
       return rtc_read(send_buf, send_bytes, recv_buf, recv_bytes);
 
     // RTC write
     case 0x08:
-      if (channel != 4)
+      if (channel != 4) {
         assert(0 && "Invalid channel for RTC write");
+        return 1;
+      }
       return rtc_write(send_buf, send_bytes, recv_buf, recv_bytes);
 
     // Unimplemented command:

--- a/si/controller.c
+++ b/si/controller.c
@@ -123,11 +123,6 @@ int pif_perform_command(struct si_controller *si,
 
         case 4:
           switch (si->eeprom.size) {
-            case 0: // No EEPROM present
-              recv_buf[0] = 0xFF;
-              recv_buf[1] = 0xFF;
-              recv_buf[2] = 0xFF;
-              break;
             case 0x200: // 4 kbit EEPROM
               recv_buf[0] = 0x00;
               recv_buf[1] = 0x80;
@@ -138,9 +133,6 @@ int pif_perform_command(struct si_controller *si,
               recv_buf[1] = 0xC0;
               recv_buf[2] = 0x00;
               break;
-            default: // Invalid EEPROM size
-              assert(0 && "Invalid EEPROM size.");
-              return 1;
           }
           break;
 
@@ -270,6 +262,7 @@ void pif_process(struct si_controller *si) {
 
       memcpy(send_buf, si->command + ptr, send_bytes);
       ptr += send_bytes;
+      memcpy(recv_buf, si->command + ptr, recv_bytes);
 
       result = pif_perform_command(si, channel,
         send_buf, send_bytes, recv_buf, recv_bytes);


### PR DESCRIPTION
Proper fix for workaround in https://github.com/DragonMinded/libdragon/pull/125#pullrequestreview-690939199

@rasky  @sp1187 

These response values have been confirmed on real hardware using the following test ROM which dumps the EEPROM status input and output data:  [eepromtest.zip](https://github.com/n64dev/cen64/files/6705772/eepromtest.zip)


The same test ROM was used to verify these changes.