### PR TITLE
Add support for 768Kbit SRAM save type

### DIFF
--- a/cen64.c
+++ b/cen64.c
@@ -140,8 +140,18 @@ int cen64_main(int argc, const char **argv) {
         break;
       case CART_DB_SAVE_TYPE_SRAM_256KBIT:
         if (options.sram_path == NULL) {
-          printf("Warning: cart saves to SRAM, but none specified (see -sram)\n");
+          printf("Warning: cart saves to 256kbit SRAM, but none specified (see -sram256k)\n");
           open_save_file(NULL, 0x8000, &sram, NULL);
+        } else if (options.sram_size != 0x8000) {
+          printf("Warning: cart saves to 256kbit SRAM, but different size specified (see -sram256k)\n");
+        }
+        break;
+      case CART_DB_SAVE_TYPE_SRAM_768KBIT:
+        if (options.sram_path == NULL) {
+          printf("Warning: cart saves to 768kbit SRAM, but none specified (see -sram768k)\n");
+          open_save_file(NULL, 0x18000, &sram, NULL);
+        } else if (options.sram_size != 0x18000) {
+          printf("Warning: cart saves to 768kbit SRAM, but different size specified (see -sram768k)\n");
         }
         break;
     }
@@ -159,7 +169,7 @@ int cen64_main(int argc, const char **argv) {
   }
 
   if (options.sram_path != NULL &&
-      open_save_file(options.sram_path, 0x8000, &sram, NULL)) {
+      open_save_file(options.sram_path, options.sram_size, &sram, NULL)) {
     cen64_alloc_cleanup();
     return EXIT_FAILURE;
   }

--- a/device/cart_db.c
+++ b/device/cart_db.c
@@ -18,6 +18,7 @@
 
 static const struct cart_db_entry cart_db_table[] = {
 
+  {"CDZ", "J",        CART_DB_SAVE_TYPE_SRAM_768KBIT,  "Dezaemon 3D"},
   {"CFZ", "EJ",       CART_DB_SAVE_TYPE_SRAM_256KBIT,  "F-Zero X (NTSC)"},
   {"CLB", "EJ",       CART_DB_SAVE_TYPE_EEPROM_4KBIT,  "Mario Party (NTSC)"},
   {"CP2", "J",        CART_DB_SAVE_TYPE_FLASH_1MBIT,   "Pokemon Stadium 2 (Japan)"},

--- a/device/cart_db.h
+++ b/device/cart_db.h
@@ -16,6 +16,7 @@ enum cart_db_save_type {
   CART_DB_SAVE_TYPE_EEPROM_16KBIT,
   CART_DB_SAVE_TYPE_FLASH_1MBIT,
   CART_DB_SAVE_TYPE_SRAM_256KBIT,
+  CART_DB_SAVE_TYPE_SRAM_768KBIT,
 };
 
 struct cart_db_entry {

--- a/device/options.c
+++ b/device/options.c
@@ -23,6 +23,7 @@ const struct cen64_options default_cen64_options = {
   NULL, // eeprom_path
   0,    // eeprom_size
   NULL, // sram_path
+  0,    // sram_size
   NULL, // flashram_path
   0,    // is_viewer_present
   NULL, // controller
@@ -122,6 +123,27 @@ int parse_options(struct cen64_options *options, int argc, const char *argv[]) {
       }
 
       options->sram_path = argv[++i];
+      options->sram_size = 0x8000;
+    }
+
+    else if (!strcmp(argv[i], "-sram256k")) {
+      if ((i + 1) >= (argc - 1)) {
+        printf("-sram256k requires a path to the save file.\n\n");
+        return 1;
+      }
+
+      options->sram_path = argv[++i];
+      options->sram_size = 0x8000;
+    }
+
+    else if (!strcmp(argv[i], "-sram768k")) {
+      if ((i + 1) >= (argc - 1)) {
+        printf("-sram768k requires a path to the save file.\n\n");
+        return 1;
+      }
+
+      options->sram_path = argv[++i];
+      options->sram_size = 0x18000;
     }
 
     else if (!strcmp(argv[i], "-flash")) {
@@ -279,7 +301,9 @@ void print_command_line_usage(const char *invokation_string) {
       "Save Options:\n"
       "  -eep4k <path>              : Path to 4 kbit EEPROM save.\n"
       "  -eep16k <path>             : Path to 16 kbit EEPROM save.\n"
-      "  -sram <path>               : Path to SRAM save.\n"
+      "  -sram <path>               : Path to 256 kbit SRAM save (alias of -sram256k).\n"
+      "  -sram256k <path>           : Path to 256 kbit SRAM save.\n"
+      "  -sram768k <path>           : Path to 768 kbit SRAM save.\n"
       "  -flash <path>              : Path to FlashRAM save.\n"
       "    For mempak see controller options.\n"
 

--- a/device/options.h
+++ b/device/options.h
@@ -22,6 +22,7 @@ struct cen64_options {
   const char *eeprom_path;
   size_t eeprom_size;
   const char *sram_path;
+  size_t sram_size;
   const char *flashram_path;
   int is_viewer_present;
 

--- a/pi/controller.c
+++ b/pi/controller.c
@@ -65,7 +65,9 @@ static int pi_dma_read(struct pi_controller *pi) {
       uint32_t sram_bank = (dest >> 18) & 3;
       // SRAM bank capacity is 256Kbits (0x8000 bytes)
       uint32_t sram_offset = (sram_bank * 0x8000) + (dest & 0x7FFF);
-      if (sram_offset + length <= pi->sram->size)
+      // Check SRAM address boundaries to prevent contiguous access across banks
+      uint32_t sram_bank_end = (sram_offset + length - 1) / 0x8000;
+      if (sram_bank == sram_bank_end && sram_offset + length <= pi->sram->size)
         memcpy((uint8_t *) (pi->sram->ptr) + sram_offset, pi->bus->ri->ram + source, length);
     }
     // FlashRAM: Save the RDRAM destination address. Writing happens
@@ -122,7 +124,9 @@ static int pi_dma_write(struct pi_controller *pi) {
       uint32_t sram_bank = (source >> 18) & 3;
       // SRAM bank capacity is 256Kbits (0x8000 bytes)
       uint32_t sram_offset = (sram_bank * 0x8000) + (source & 0x7FFF);
-      if (sram_offset + length <= pi->sram->size)
+      // Check SRAM address boundaries to prevent contiguous access across banks
+      uint32_t sram_bank_end = (sram_offset + length - 1) / 0x8000;
+      if (sram_bank == sram_bank_end && sram_offset + length <= pi->sram->size)
         memcpy(pi->bus->ri->ram + dest, (const uint8_t *) (pi->sram->ptr) + sram_offset, length);
     }
     // FlashRAM


### PR DESCRIPTION
![2021-11-30_10-48](https://user-images.githubusercontent.com/11916110/144080223-66ae073e-9c14-4732-ad50-cd0551195685.png)

## LibDragon Save Type Detection Test ROM: [savetest.zip](https://github.com/n64dev/cen64/files/7627030/savetest.zip) ([source](https://raw.githubusercontent.com/meeq/libdragon/example/savetest/examples/savetest/savetest.c))

### Highlights

* Fixes a segmentation fault when trying to access SRAM > 256Kbit
* Implements "banked" 768Kbit SRAM as used exclusively by "Dezaemon 3D":
  * The cartridge contains three 256Kbit SRAM chips and uses bank selection bits in the address.
  * The 768Kbits of SRAM cannot be accessed contiguously, only one bank at a time.
* Introduces options for specifying SRAM capacity: `-sram256k` (alias of `-sram`) and `-sram768k`

### Intentional omissions
The test ROM includes checks for save types that should not exist. These save types are intentionally not implemented by cen64:

* `1Mbit SRAM (Banked)`
* `768Kbit SRAM (Contiguous)`
* `1Mbit SRAM (Contiguous)`

### Known issues
Dezaemon 3D boots, shows the publisher logo, then gets stuck at the "sad man screen" that appears to indicate SRAM errors:
![2021-11-30_11-01](https://user-images.githubusercontent.com/11916110/144082574-d803f775-14c6-400c-8fc8-1219ab1e5582.png)

Additional investigation and research is needed to get Dezaemon 3D working.