### PR TITLE
Show Windows console when isviewer is present.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ set(OS_POSIX_SOURCES
 
 set(OS_WINAPI_SOURCES
   ${PROJECT_SOURCE_DIR}/os/winapi/alloc.c
+  ${PROJECT_SOURCE_DIR}/os/winapi/console.c
   ${PROJECT_SOURCE_DIR}/os/winapi/cpuid.c
   ${PROJECT_SOURCE_DIR}/os/winapi/gl_config.c
   ${PROJECT_SOURCE_DIR}/os/winapi/gl_window.c

--- a/cen64.c
+++ b/cen64.c
@@ -21,6 +21,9 @@
 #include "os/common/rom_file.h"
 #include "os/common/save_file.h"
 #include "os/cpuid.h"
+#ifdef _WIN32
+#include "os/winapi/console.h"
+#endif
 #include "pi/is_viewer.h"
 #include "thread.h"
 #include <stdlib.h>
@@ -177,6 +180,9 @@ int cen64_main(int argc, const char **argv) {
       return EXIT_FAILURE;
     } else {
       is_in = &is;
+      #ifdef _WIN32
+      show_console();
+      #endif
     }
   }
 

--- a/os/winapi/console.c
+++ b/os/winapi/console.c
@@ -1,0 +1,31 @@
+//
+// os/winapi/console.c
+//
+// Functions for manipulating the console.
+//
+// CEN64: Cycle-Accurate Nintendo 64 Emulator.
+// Copyright (C) 2015, Tyler J. Stachecki.
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+
+#include "cen64.h"
+#include <windows.h>
+
+// "Hides" the console window (after waiting for input).
+void hide_console(void) {
+  printf("\n");
+  system("PAUSE");
+
+  FreeConsole();
+}
+
+// "Unhides" the console window.
+void show_console(void) {
+  if (AttachConsole(ATTACH_PARENT_PROCESS) == 0)
+    AllocConsole();
+
+  freopen("CONOUT$", "wb", stdout);
+  freopen("CONOUT$", "wb", stderr);
+}

--- a/os/winapi/console.h
+++ b/os/winapi/console.h
@@ -1,0 +1,16 @@
+//
+// os/winapi/console.h: Console manipulation functions
+//
+// CEN64: Cycle-Accurate Nintendo 64 Emulator.
+// Copyright (C) 2015, Tyler J. Stachecki.
+//
+// This file is subject to the terms and conditions defined in
+// 'LICENSE', which is part of this source code package.
+//
+#ifndef CEN64_OS_WINAPI_CONSOLE
+#define CEN64_OS_WINAPI_CONSOLE
+
+void show_console(void);
+void hide_console(void);
+
+#endif

--- a/os/winapi/main.c
+++ b/os/winapi/main.c
@@ -30,20 +30,3 @@ int WINAPI WinMain(HINSTANCE hInstance,
 
   return status;
 }
-
-// "Hides" the console window (after waiting for input).
-void hide_console(void) {
-  printf("\n");
-  system("PAUSE");
-
-  FreeConsole();
-}
-
-// "Unhides" the console window.
-void show_console(void) {
-  AllocConsole();
-
-  freopen("CONOUT$", "wb", stdout);
-  freopen("CONOUT$", "wb", stderr);
-}
-


### PR DESCRIPTION
ISViewer needs a console to be useful, but cen64 on Windows builds as a windowed application so the output is lost. This commit fixes it by calling the existing `show_console` function in case isviewer is requested. It also improves `show_console` to attach to the existing console when cen64 is launched from the command prompt.