### PR TITLE
Fix a few pipelining bugs with RSP

### DIFF
--- a/rsp/cp0.h
+++ b/rsp/cp0.h
@@ -55,6 +55,7 @@
 #define SP_SET_SIG6               0x00400000
 #define SP_CLR_SIG7               0x00800000
 #define SP_SET_SIG7               0x01000000
+#define SP_SET_BROKE              0x80000000  // Does not exist in hardware, used only internally
 
 struct rsp;
 
@@ -84,6 +85,8 @@ void RSP_MTC0(struct rsp *rsp, uint32_t iw, uint32_t rs, uint32_t rt);
 
 uint32_t rsp_read_cp0_reg(struct rsp *rsp, unsigned src);
 void rsp_write_cp0_reg(struct rsp *rsp, unsigned dest, uint32_t rt);
+
+void rsp_status_write(struct rsp *rsp, uint32_t rt);
 
 cen64_cold void rsp_cp0_init(struct rsp *rsp);
 

--- a/rsp/functions.c
+++ b/rsp/functions.c
@@ -282,16 +282,17 @@ void RSP_BGTZ_BLEZ(
 //
 void RSP_BREAK(struct rsp *rsp,
   uint32_t iw, uint32_t rs, uint32_t rt) {
-  struct rsp_exdf_latch *exdf_latch = &rsp->pipeline.exdf_latch;
-
-  uint32_t result = rsp->regs[RSP_CP0_REGISTER_SP_STATUS] |
-    (SP_STATUS_HALT | SP_STATUS_BROKE);
+  struct rsp_dfwb_latch *dfwb_latch = &rsp->pipeline.dfwb_latch;
 
   if (rsp->regs[RSP_CP0_REGISTER_SP_STATUS] & SP_STATUS_INTR_BREAK)
     signal_rcp_interrupt(rsp->bus->vr4300, MI_INTR_SP);
 
-  exdf_latch->result.dest = RSP_CP0_REGISTER_SP_STATUS;
-  exdf_latch->result.result = result;
+  // Prepare to halt the processor at the beginning of next cycle
+  // (when the WB stage will run). This make sure that executing BREAK
+  // in a delay slot works correctly: the processor halts just before
+  // running the branch target opcode, and resume from there when un-halted.
+  dfwb_latch->result.dest = RSP_CP0_REGISTER_SP_STATUS;
+  dfwb_latch->result.result = SP_SET_HALT | SP_SET_BROKE;
 }
 
 //


### PR DESCRIPTION
1) Setting SP_PC was not resetting the pipeline. This caused that
changing the PC within a HALT/UNHALT sequence was still causing
previous instructions in the pipeline (at the old address) to be
executed. This is not how the hardware works: SP_PC is immediate and
discards the whole pipeline.

2) BREAK did not correctly halt the processor at the right instruction,
which in turn caused resumption after HALT to execute the wrong
set of instructions. This was caused by the fact that the SP_STATUS
change was written into the EXDF latch, which in turn takes 3 cycles
to reach completion. Instead, we now use the DFWB latch, and we cause
it to abort the RSP cycle if the processor is halted. This happens
at the beginning of next cycle, which is the correct moment.

2) Since we are at it, use rsp_status_write to modify the RSP in
this case, rather than a direct write to the register. This change
fixes a race condition: SP_STATUS must be accessed atomically when
cen64 runs in multithreaded mode. To use rsp_status_write, we need
to introduce a nonexisting SP_SET_BROKE bit: we use the MSB, but then
mask it out in MTC0 to avoid some code to inadvertently have that bit
set.

3) When unhalting after BREAK, it's important to keep the correct
PC which comes from the EX stage (the one that was going to be
executed if BREAK didn't occur). Before, it was using the IF PC (fetch)
which is farther in the future.

Fixes #155