### PR TITLE
Fix SRA/SRAV opcodes

### DIFF
--- a/vr4300/functions.c
+++ b/vr4300/functions.c
@@ -1452,7 +1452,7 @@ int VR4300_SRA(struct vr4300 *vr4300,
   unsigned dest = GET_RD(iw);
   unsigned sa = iw >> 6 & 0x1F;
 
-  exdc_latch->result = (int32_t) rt >> sa;
+  exdc_latch->result = (int32_t) (rt >> sa);
   exdc_latch->dest = dest;
   return 0;
 }
@@ -1466,7 +1466,7 @@ int VR4300_SRAV(struct vr4300 *vr4300,
   unsigned dest = GET_RD(iw);
   unsigned sa = rs & 0x1F;
 
-  exdc_latch->result = (int32_t) rt >> sa;
+  exdc_latch->result = (int32_t) (rt >> sa);
   exdc_latch->dest = dest;
   return 0;
 }


### PR DESCRIPTION
These opcodes surprisingly let the higher bits shift in into the lower 32-bits,
before sign-extension.

Attached ROMs can be used for testing:
[sra.zip](https://github.com/n64dev/cen64/files/7885100/sra.zip)

Origin: https://github.com/Dillonb/n64-tests/releases/tag/latest
