### PR TITLE
Avoid length overflow when fetch starts beyond ROM

### DIFF
--- a/pi/controller.c
+++ b/pi/controller.c
@@ -90,7 +90,9 @@ static int pi_dma_read(struct pi_controller *pi) {
 
 static void pi_rom_fetch(struct pi_controller *pi, uint32_t source, int32_t length, uint8_t *dest) {
   int l = length;
-  if (source + length > pi->rom_size)
+  if (source >= pi->rom_size)
+    l = 0;
+  else if (source + length > pi->rom_size)
     l = pi->rom_size - source;
   memcpy(dest, pi->rom + source, l);
 


### PR DESCRIPTION
 Read beyond ROM was causing a segfault since #202.