### PR TITLE
cen64: cleanup console/windowed support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,7 +385,6 @@ set(VR4300_SOURCES
 #
 if (DEFINED WIN32)
   include_directories(${PROJECT_SOURCE_DIR}/os/winapi)
-  set(EXTRA_OS_EXE WIN32)
   if (NOT MSVC)
     set(EXTRA_OS_LIBS mingw32 opengl32 winmm ws2_32)
   else ()

--- a/cen64.c
+++ b/cen64.c
@@ -56,6 +56,10 @@ int cen64_main(int argc, const char **argv) {
   struct save_file flashram;
   struct is_viewer is, *is_in = NULL;
 
+#ifdef _WIN32
+  check_start_from_explorer();
+#endif
+
   if (!cart_db_is_well_formed()) {
     printf("Internal cart detection database is not well-formed.\n");
     return EXIT_FAILURE;
@@ -190,9 +194,6 @@ int cen64_main(int argc, const char **argv) {
       return EXIT_FAILURE;
     } else {
       is_in = &is;
-      #ifdef _WIN32
-      show_console();
-      #endif
     }
   }
 

--- a/device/options.c
+++ b/device/options.c
@@ -11,6 +11,9 @@
 #include "common.h"
 #include "options.h"
 #include "si/pak.h"
+#ifdef _WIN32
+#include "os/winapi/console.h"
+#endif
 
 static int parse_controller_options(const char *str, int *num, struct controller *opt);
 
@@ -27,9 +30,6 @@ const struct cen64_options default_cen64_options = {
   NULL, // flashram_path
   0,    // is_viewer_present
   NULL, // controller
-#ifdef _WIN32
-  false, // console
-#endif
   false, // enable_debugger
   false, // enable_profiling
   false, // multithread
@@ -43,13 +43,6 @@ int parse_options(struct cen64_options *options, int argc, const char *argv[]) {
   int i;
 
   for (i = 0; i < argc - 1; i++) {
-#ifdef _WIN32
-    if (!strcmp(argv[i], "-console"))
-      options->console = true;
-
-    else
-#endif
-
     if (!strcmp(argv[i], "-debug")) {
       options->enable_debugger = true;
 
@@ -275,9 +268,6 @@ void print_command_line_usage(const char *invokation_string) {
   printf("%s [Options] <PIF IPL ROM Path> [Cart ROM Path]\n\n"
 
     "Options:\n"
-#ifdef _WIN32
-      "  -console                   : Creates/shows this system console window.\n"
-#endif
       "  -debug [addr][:port]       : Starts the debugger on interface:port.\n"
       "                               By default, CEN64 uses localhost:64646.\n"
       "                               NOTE: the debugger is not implemented yet.\n"

--- a/device/options.h
+++ b/device/options.h
@@ -28,10 +28,6 @@ struct cen64_options {
 
   struct controller *controller;
 
-#ifdef _WIN32
-  bool console;
-#endif
-
   bool enable_debugger;
   bool enable_profiling;
   bool multithread;

--- a/os/winapi/console.c
+++ b/os/winapi/console.c
@@ -13,6 +13,19 @@
 #include "cen64.h"
 #include <windows.h>
 
+bool has_console(void) {
+  DWORD procId;
+  DWORD count = GetConsoleProcessList(&procId, 1);
+  return (count >= 2);
+}
+
+void check_start_from_explorer(void) {
+  if (has_console()) return;
+  system("cmd /S /K \"echo cen64 is a command-line application, don't double-click on it! & echo: & echo Type ^\"cen64.exe^\" from this prompt to get the usage.\"");
+  exit(0);
+}
+
+
 // "Hides" the console window (after waiting for input).
 void hide_console(void) {
   printf("\n");

--- a/os/winapi/console.h
+++ b/os/winapi/console.h
@@ -12,5 +12,7 @@
 
 void show_console(void);
 void hide_console(void);
+bool has_console(void);
+void check_start_from_explorer(void);
 
 #endif


### PR DESCRIPTION
Currently, the experience of cen64 on Windows is not the
greatest, to be kind. If you get the binary and double-click on it,
you get nothing (no feedback whatsoever). If you run it from the
console, you get nothing (no command line help is shown). I am not sure
how Windows users ever manage to use it.

This happens because the binary is linked as a windowed application,
but when run with no command line options, it exits after printing
the help with printf, which does nothing since no console is
attached to the windowed application.

This PR improves the usability on Windows. It compiles cen64 has a
console application (as was meant to be used), so that the help text
or any other stdout/stderr output is now visible on console. Moreover,
to provide a decent experience to users double-clicking on the
binary, it displays an error message explaining that it should be run
from the command line instead.