### PR TITLE
Help users discover -is-viewer

### DIFF
--- a/cen64.c
+++ b/cen64.c
@@ -196,16 +196,12 @@ int cen64_main(int argc, const char **argv) {
       memset(flashram.ptr, 0xFF, FLASHRAM_SIZE);
   }
 
-  if (options.is_viewer_present) {
-    if (!is_viewer_init(&is)) {
-      cen64_alloc_cleanup();
-      return EXIT_FAILURE;
-    } else {
-      is_in = &is;
-    }
+  if (!is_viewer_init(&is, options.is_viewer_output)) {
+    cen64_alloc_cleanup();
+    return EXIT_FAILURE;
+  } else {
+    is_in = &is;
   }
-
-
 
   // Allocate memory for and create the device.
   if (cen64_alloc(&cen64_device_mem, sizeof(*device), false) == NULL) {

--- a/device/options.c
+++ b/device/options.c
@@ -28,7 +28,7 @@ const struct cen64_options default_cen64_options = {
   NULL, // sram_path
   0,    // sram_size
   NULL, // flashram_path
-  0,    // is_viewer_present
+  0,    // is_viewer_output
   NULL, // controller
   false, // enable_debugger
   false, // enable_profiling
@@ -159,7 +159,7 @@ int parse_options(struct cen64_options *options, int argc, const char *argv[]) {
     }
 
     else if (!strcmp(argv[i], "-is-viewer"))
-      options->is_viewer_present = 1;
+      options->is_viewer_output = 1;
 
     else if (!strcmp(argv[i], "-controller")) {
       int num;
@@ -289,7 +289,7 @@ void print_command_line_usage(const char *invokation_string) {
       "  -headless                  : Run emulator without user-interface components.\n"
       "  -noaudio                   : Run emulator without audio.\n"
       "  -novideo                   : Run emulator without video.\n"
-      "  -is-viewer                 : IS Viewer 64 present.\n"
+      "  -is-viewer                 : Show IS Viewer 64 output.\n"
       "\n"
       "Controller Options:\n"
       "  -controller num=<1-4>      : Controller with no pak.\n"

--- a/device/options.h
+++ b/device/options.h
@@ -24,7 +24,7 @@ struct cen64_options {
   const char *sram_path;
   size_t sram_size;
   const char *flashram_path;
-  int is_viewer_present;
+  int is_viewer_output;
 
   struct controller *controller;
 

--- a/pi/is_viewer.c
+++ b/pi/is_viewer.c
@@ -7,7 +7,7 @@
 // arbitrarily chosen
 #define IS_BUFFER_SIZE 0x200
 
-int is_viewer_init(struct is_viewer *is) {
+int is_viewer_init(struct is_viewer *is, int is_viewer_output) {
   memset(is, 0, sizeof(*is));
 
   // TODO support other addresses
@@ -17,6 +17,7 @@ int is_viewer_init(struct is_viewer *is) {
   is->buffer = calloc(IS_BUFFER_SIZE, 1);
   is->output_buffer = calloc(IS_BUFFER_SIZE, 1);
   is->output_buffer_conv = calloc(IS_BUFFER_SIZE * 3, 1);
+  is->show_output = is_viewer_output;
 
   is->cd = iconv_open("UTF-8", "EUC-JP");
 
@@ -61,7 +62,12 @@ int write_is_viewer(struct is_viewer *is, uint32_t address, uint32_t word, uint3
         memset(is->output_buffer_conv, 0, IS_BUFFER_SIZE * 3);
         iconv(is->cd, &inptr, &len, &outptr, &outlen);
 
-        printf("%s", is->output_buffer_conv);
+        if (is->show_output)
+          printf("%s", is->output_buffer_conv);
+        else if (!is->output_warning) {
+          printf("ISViewer debugging output detected and suppressed.\nRun cen64 with option -is-viewer to display it\n");
+          is->output_warning = 1;
+        }
 
         memset(is->output_buffer, 0, is->output_buffer_pos);
         is->output_buffer_pos = 0;

--- a/pi/is_viewer.h
+++ b/pi/is_viewer.h
@@ -15,11 +15,13 @@ struct is_viewer {
   uint8_t *output_buffer;
   size_t output_buffer_pos;
   uint8_t *output_buffer_conv;
+  int show_output;
+  int output_warning;
 
   iconv_t cd;
 };
 
-int is_viewer_init(struct is_viewer *is);
+int is_viewer_init(struct is_viewer *is, int show_output);
 int is_viewer_map(struct is_viewer *is, uint32_t address);
 int read_is_viewer(struct is_viewer *is, uint32_t address, uint32_t *word);
 int write_is_viewer(struct is_viewer *is, uint32_t address, uint32_t word, uint32_t dqm);


### PR DESCRIPTION
IS Viewer emulation is currently gated by a command-line flag. All
other major emulators supporting ISViewer (Ares, dillonb, m64p) enable
it by default, and it does not seem to create any problem.

To help homebrew developers discover the feature without showing logs
by default, change the code to always emulate the ISViewer hardware
and add a warning if the ROM uses it but the command line flag was
not specified. This should point users towards correct usage, and
prevents possibly-verbose logs to be shown by default.