### PR TITLE
Rewrite IS-Viewer 64 console output emulation

### DIFF
--- a/pi/is_viewer.h
+++ b/pi/is_viewer.h
@@ -5,7 +5,7 @@
 
 // IS Viewer
 #define IS_VIEWER_BASE_ADDRESS    0x13FF0000
-#define IS_VIEWER_ADDRESS_LEN     0x00001000
+#define IS_VIEWER_ADDRESS_LEN     0x00010000
 
 struct is_viewer {
   uint32_t base_address;
@@ -13,7 +13,6 @@ struct is_viewer {
 
   uint8_t *buffer;
   uint8_t *output_buffer;
-  size_t output_buffer_pos;
   uint8_t *output_buffer_conv;
   int show_output;
   int output_warning;


### PR DESCRIPTION
- Based on the OoT decompilation project source code, the IS-Viewer 64 is an asynchronous ring buffer. See: https://github.com/zeldaret/oot/blob/984871eb3892a081d42209a62ca8951cbb64dd31/src/boot/is_debug.c
- The hardware has 64 KB of work RAM for the buffer.
    - 32 bytes are reserved.
    - 4 bytes of the reserved area are used for the write head, which the game updates after it has produced bytes into the ring buffer.
    - Another 4 bytes of the reserved area are used for the read head, which the IS-Viewer 64 hardware presumably updates as it consumes bytes from the ring buffer.
- This patch rewrites the IS-Viewer 64 emulation to more closely follow what the OoT code is doing.
- Primarily the read head is updated after bytes are consumed from the ring bugger.
- Secondarily, the size of the ring buffer has been increased to 64 KB.
- I removed some memory zeroing which was both unnecessary and incorrect.
    - IS-Viewer 64 must not zero the buffer as it consumes bytes; this would cause a race condition with the producer which must read-modify-write whole words on PI to produce individual bytes.
- Tested against OoT patched with IS-Viewer 64 output.
- This notably breaks my implementation of IS-Viewer 64 console output, since it was based only on the previous version of Cen64's IS-Viewer 64 emulation. The motivation for this patch is to avoid this specific problem with bad emulation resulting in incorrect homebrew code being written for it.
    - This situation with incorrect homebrew code can only be addressed by rewriting the console output to implement the write-side of the ring buffer semantics.